### PR TITLE
Add logit processor for better CoC generation

### DIFF
--- a/src/alpamayo_r1/models/alpamayo_r1.py
+++ b/src/alpamayo_r1/models/alpamayo_r1.py
@@ -65,14 +65,8 @@ class ExpertLogitsProcessor(LogitsProcessor):
         Returns:
             torch.FloatTensor: The modified scores tensor with trajectory tokens masked out (set to -inf).
         """
-        # Create a mask filled with zeros
-        mask = torch.zeros_like(scores)
-        mask[:, self.traj_token_offset : self.traj_token_offset + self.traj_vocab_size] = float(
-            "-inf"
-        )
-
-        # Apply the mask to the scores
-        scores = scores + mask
+        # Directly assign -inf to the trajectory token positions in the scores tensor
+        scores[:, self.traj_token_offset : self.traj_token_offset + self.traj_vocab_size] = float('-inf')
         return scores
 
 


### PR DESCRIPTION
This MR adds a logit processor to mask out the discrete trajectory tokens that are not used for the expert model for better CoC generation.