### PR TITLE
Replace assert with ValueError in create_message()

### DIFF
--- a/src/alpamayo_r1/helper.py
+++ b/src/alpamayo_r1/helper.py
@@ -28,7 +28,7 @@ BASE_PROCESSOR_NAME = "Qwen/Qwen3-VL-2B-Instruct"
 def create_message(frames: torch.Tensor):
     """Construct the message using images and cot."""
     if frames.ndim != 4:
-        raise ValueError(f"frames.ndim={frames.ndim}, expected 4 (N, C, H, W)")
+        raise ValueError(f"{frames.ndim=}, expected 4 (N, C, H, W)")
 
     # NOTE: we expand the padding tokens to match training, so we can directly apply native processor from VLM.
     num_traj_token = 48


### PR DESCRIPTION
Assert statements can be disabled with python -O flag, which would silently skip validation. Using ValueError ensures the check always runs and provides a clear exception type for callers to handle.