### PR TITLE
Update physical_ai_av version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "hydra-colorlog>=1.2.0",
   "hydra-core>=1.3.2",
   "pandas>=2.3.3",
-  "physical_ai_av>=0.1.0",
+  "physical_ai_av>=0.2.0",
   "pillow>=12.0.0",
   "torch==2.8.0",
   "torchvision>=0.23.0",


### PR DESCRIPTION
This is to resolve errors like https://github.com/NVlabs/alpamayo/issues/59#issue-4131548025 due to physical ai av package updates