### PR TITLE
Replace assert with ValueError in load_physical_aiavdataset()

### DIFF
--- a/src/alpamayo_r1/load_physical_aiavdataset.py
+++ b/src/alpamayo_r1/load_physical_aiavdataset.py
@@ -95,9 +95,12 @@ def load_physical_aiavdataset(
         maybe_stream=maybe_stream,
     )
 
-    assert t0_us > num_history_steps * time_step * 1_000_000, (
-        "t0_us must be greater than the history time range"
-    )
+    history_time_range_us = num_history_steps * time_step * 1_000_000
+    if t0_us <= history_time_range_us:
+        raise ValueError(
+            f"{t0_us=} must be greater than the history time range "
+            f"({history_time_range_us=} us)"
+        )
 
     # Compute timestamps for trajectory sampling
     # History: [..., t0-0.2s, t0-0.1s, t0] (num_history_steps points ending at t0)


### PR DESCRIPTION
## Summary

Replace the `assert` statement in `load_physical_aiavdataset()` with a `ValueError`, mirroring the pattern of merged PR #50 (which made the same change in `helper.create_message()`).

### Why

`assert` statements are stripped when Python runs with `-O` (optimization mode), so the `t0_us` validation would silently disappear and downstream timestamp arithmetic would produce confusing failures (negative offsets, out-of-range queries) instead of a clear input-validation error.

`ValueError` is the correct exception type for invalid argument values and is always raised regardless of optimization flags.

### Change

`src/alpamayo_r1/load_physical_aiavdataset.py`:

```diff
-    assert t0_us > num_history_steps * time_step * 1_000_000, (
-        "t0_us must be greater than the history time range"
-    )
+    history_time_range_us = num_history_steps * time_step * 1_000_000
+    if t0_us <= history_time_range_us:
+        raise ValueError(
+            f"{t0_us=} must be greater than the history time range "
+            f"({history_time_range_us=} us)"
+        )
```

The error message now includes the actual computed threshold so the caller can see which value they violated.

## Test plan

- [x] `python -c "import ast; ast.parse(open('src/alpamayo_r1/load_physical_aiavdataset.py').read())"` — syntax OK
- [x] Behavior preserved: passing `t0_us` greater than `num_history_steps * time_step * 1_000_000` proceeds as before; smaller/equal values now raise `ValueError` with a descriptive message instead of `AssertionError`.
- [ ] Reviewer: confirm the message format `f"{name=}"` is consistent with the project style (already used in `helper.py` after #50).

## References

- PR #50 — same pattern applied to `create_message()` in `helper.py`