### PR TITLE
Replace assert with ValueError in public-API input validation

### DIFF
--- a/src/alpamayo_r1/models/alpamayo_r1.py
+++ b/src/alpamayo_r1/models/alpamayo_r1.py
@@ -154,7 +154,10 @@ class AlpamayoR1(ReasoningVLA):
         ego_history_xyz = data["ego_history_xyz"]
         ego_history_rot = data["ego_history_rot"]
         B, n_traj_group, _, _ = ego_history_xyz.shape
-        assert n_traj_group == 1, "Only one trajectory group is supported for inference."
+        if n_traj_group != 1:
+            raise ValueError(
+                f"Only one trajectory group is supported for inference, got {n_traj_group=}"
+            )
         tokenized_data = data["tokenized_data"]
         input_ids = tokenized_data.pop("input_ids")
         traj_data_vlm = {

--- a/src/alpamayo_r1/models/base_model.py
+++ b/src/alpamayo_r1/models/base_model.py
@@ -101,8 +101,15 @@ def tokenize_history_trajectory(
     Returns:
         torch.Tensor: [B, n_traj * tokens_per_history_traj]
     """
-    assert "ego_history_xyz" in traj_data
-    assert traj_data["ego_history_xyz"].ndim == 4, "ego_history_xyz must be 4D of [B, n_traj, T, 3]"
+    if "ego_history_xyz" not in traj_data:
+        raise ValueError(
+            f"`traj_data` is missing required key 'ego_history_xyz'; got keys {list(traj_data)}"
+        )
+    if traj_data["ego_history_xyz"].ndim != 4:
+        raise ValueError(
+            "ego_history_xyz must be 4D of [B, n_traj, T, 3], got "
+            f"shape {tuple(traj_data['ego_history_xyz'].shape)}"
+        )
 
     B = traj_data["ego_history_xyz"].shape[0]
     hist_xyz = traj_data["ego_history_xyz"].flatten(start_dim=0, end_dim=1)


### PR DESCRIPTION
## Summary

Continues the pattern of merged PR #50 (`helper.create_message`) and PR #73 (`load_physical_aiavdataset`): convert the remaining public-facing input validators from `assert` to `ValueError`, so they survive `python -O` and emit a clear exception type users can catch.

## Changes

### 1. `tokenize_history_trajectory` (`src/alpamayo_r1/models/base_model.py:104-105`)

```diff
-    assert "ego_history_xyz" in traj_data
-    assert traj_data["ego_history_xyz"].ndim == 4, "ego_history_xyz must be 4D of [B, n_traj, T, 3]"
+    if "ego_history_xyz" not in traj_data:
+        raise ValueError(
+            f"`traj_data` is missing required key 'ego_history_xyz'; got keys {list(traj_data)}"
+        )
+    if traj_data["ego_history_xyz"].ndim != 4:
+        raise ValueError(
+            "ego_history_xyz must be 4D of [B, n_traj, T, 3], got "
+            f"shape {tuple(traj_data['ego_history_xyz'].shape)}"
+        )
```

The first assert had no message; the second one's was correct but `assert` got stripped under `-O`. Both errors now include the actual offending value (key set or shape) for faster diagnosis.

### 2. `AlpamayoR1.sample_trajectories_from_data_with_vlm_rollout` (`src/alpamayo_r1/models/alpamayo_r1.py:157`)

```diff
-        assert n_traj_group == 1, "Only one trajectory group is supported for inference."
+        if n_traj_group != 1:
+            raise ValueError(
+                f"Only one trajectory group is supported for inference, got {n_traj_group=}"
+            )
```

## Scope

These three call sites — plus the two already addressed in #50 and #73 — are **all** the public-facing input validators that were using `assert`. I deliberately left the remaining `assert`s as-is because they guard internal invariants, not caller-supplied input:

| File:Line | Why kept as `assert` |
|---|---|
| `models/base_model.py:266` | `len(discrete_tokens) == num_new_tokens` — internal post-condition of `tokenizer.add_tokens` |
| `models/action_in_proj.py:43` | `1 <= num_enc_layers` — config-time check inside private mixin |
| `models/alpamayo_r1.py` (sample loop, internal) | various sequence-length / token-position invariants |
| `chat_template/conversation.py:38, 115, 195, 227` | template-construction internal invariants |
| `processor/qwen_processor.py:128, 189, 195, 294` | processor-internal batching invariants |
| `utils/get_label_mask.py:66, 69, 123, 134` | label-mask internal balance invariants |
| `action_space/discrete_action_space.py:37` | dim-list parity inside the constructor |

If you'd prefer a sweeping conversion to `ValueError` everywhere, happy to do that in a follow-up — but the convention here mirrors the way #50 was framed (only the user-input boundary).

## Test plan

- [x] Both files parse: `python -c \"import ast; [ast.parse(open(f).read()) for f in ['src/alpamayo_r1/models/base_model.py', 'src/alpamayo_r1/models/alpamayo_r1.py']]\"`
- [x] No semantics change: every check fires under exactly the same condition; just a different exception class with a more informative message.
- [x] Behavior under `python -O`: the validation now runs (previously stripped). For valid inputs this is a no-op; for invalid inputs callers see `ValueError` instead of an opaque downstream `AttributeError`/`KeyError`.