### PR TITLE
Expand Troubleshooting with HF auth, FA2 cu_seqlens, and smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,29 @@ alpamayo/
 
 ## Troubleshooting
 
+### `IndexError: list index out of range` when loading the dataset
+
+If `load_physical_aiavdataset(...)` fails with a traceback ending in:
+
+```
+File ".../physical_ai_av/utils/hf_interface.py", line 231, in download_file
+    self.api.get_paths_info(paths=[filename], **self.repo_snapshot_info)[0].size
+IndexError: list index out of range
+```
+
+…you are not authenticated with HuggingFace, or you have not been granted
+access to the gated `nvidia/PhysicalAI-Autonomous-Vehicles` dataset.
+
+1. Request access at
+   [huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles).
+2. Authenticate locally:
+   ```bash
+   pip install -U huggingface_hub
+   hf auth login
+   ```
+
+See [§3 Authenticate with HuggingFace](#3-authenticate-with-huggingface) for details.
+
 ### Flash Attention issues
 
 The model uses Flash Attention 2 by default. If you encounter compatibility issues:
@@ -200,6 +223,19 @@ The model uses Flash Attention 2 by default. If you encounter compatibility issu
 config.attn_implementation = "sdpa"
 ```
 
+### `RuntimeError: cu_seqlens_q must have shape (batch_size + 1)` with FlashAttention-2
+
+This crash specifically affects the **diffusion expert** during trajectory
+sampling when FlashAttention-2 is forced globally. The expert step uses a
+custom 4D additive attention mask to handle variable-length VLM rollouts;
+FlashAttention-2's transformers integration cannot consume that mask shape.
+
+The shipped configuration sets the VLM to FA2 (where the long prefill
+benefits) and keeps the expert on SDPA, so this error should not appear
+under default usage. If you have manually flipped `attn_implementation`
+across the entire model, restore the default split or pin the expert
+back to SDPA via `expert_cfg.attn_implementation = "sdpa"`.
+
 ### CUDA out-of-memory errors
 
 If you encounter OOM errors:
@@ -207,6 +243,22 @@ If you encounter OOM errors:
 1. Ensure you have a GPU with at least 24 GB VRAM
 2. Reduce `num_traj_samples` if generating multiple trajectories
 3. Close other GPU-intensive applications
+
+### Verifying your local installation
+
+A quick smoke test before debugging anything else:
+
+```bash
+python -c "import torch; print(torch.cuda.is_available(), torch.cuda.device_count())"
+python -c "from alpamayo_r1.models.alpamayo_r1 import AlpamayoR1; print('alpamayo_r1 import OK')"
+huggingface-cli whoami    # Should print your username if authenticated
+```
+
+If all three succeed, run the end-to-end check:
+
+```bash
+python src/alpamayo_r1/test_inference.py
+```
 
 ## License
 


### PR DESCRIPTION
## Summary

Doc-only expansion of the existing Troubleshooting section in `README.md`. No code changes. Addresses several recurring issues by giving users a fast path to a fix without filing a new ticket.

## What's added

### 1. `IndexError: list index out of range` when loading the dataset
Reproduces the exact traceback fragment users see when HF auth or gated-dataset access is missing, and points to the existing §3 Authenticate with HuggingFace step. Pairs with PR #74 which surfaces the same diagnostic at runtime.

→ Addresses #59, #61.

### 2. `RuntimeError: cu_seqlens_q must have shape (batch_size + 1)` with FlashAttention-2
One-paragraph explanation: the diffusion expert uses a 4D additive attention mask to handle variable-length VLM rollouts, which FA2 cannot consume. The shipped configuration keeps the VLM on FA2 and the expert on SDPA — so the error only appears when users force FA2 globally. Mentions the `expert_cfg.attn_implementation = "sdpa"` escape hatch.

→ Addresses #52. Pairs with PR #75 which makes this default explicit in code.

### 3. Verifying your local installation
Three quick import-level smoke tests (`torch.cuda.is_available()`, `from alpamayo_r1.models.alpamayo_r1 import AlpamayoR1`, `huggingface-cli whoami`) plus the end-to-end `test_inference.py` command, so users can bisect a broken environment in a few seconds.

→ Addresses #33.

## Why this is worth doing as docs

Looking at the open-issue distribution: the same handful of root causes (HF auth, FA2 incompatibility with the expert, missing GPU/imports) explain a large fraction of bug reports. A focused Troubleshooting section is the smallest-blast-radius fix that also reduces maintainer triage load.

## Test plan

- [x] Markdown renders cleanly.
- [x] Anchors `#3-authenticate-with-huggingface` resolve to the existing heading.
- [x] No links to non-existent files or future PR numbers.