### PR TITLE
Preserve integer/bool tensor dtype in to_device() (fixes #36)

### DIFF
--- a/src/alpamayo_r1/helper.py
+++ b/src/alpamayo_r1/helper.py
@@ -85,13 +85,17 @@ def to_device(
     device: str | torch.device | None = None,
     dtype: torch.dtype | None = None,
 ) -> Any:
-    """Recursively cast data into the specified device, dtype."""
+    """Recursively cast data into the specified device, dtype.
+
+    ``dtype`` is only applied to floating-point tensors. Integer and boolean
+    tensors (e.g. ``input_ids``, ``attention_mask``) are moved to ``device``
+    with their dtype preserved so that mixed-precision inference does not
+    accidentally cast token IDs to floats and break embedding lookups.
+    """
     if isinstance(data, torch.Tensor):
-        data = data.to(
-            device=device,
-            dtype=dtype,
-        )
-        return data
+        if dtype is not None and data.is_floating_point():
+            return data.to(device=device, dtype=dtype)
+        return data.to(device=device)
     elif isinstance(data, collections.abc.Mapping):
         return {key: to_device(data[key], device=device, dtype=dtype) for key in data}
     elif isinstance(data, collections.abc.Sequence) and not isinstance(data, (str, bytes)):

--- a/src/alpamayo_r1/test_helper.py
+++ b/src/alpamayo_r1/test_helper.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``alpamayo_r1.helper``.
+
+Run:
+    pytest src/alpamayo_r1/test_helper.py -v
+"""
+
+from __future__ import annotations
+
+import torch
+
+from alpamayo_r1.helper import to_device
+
+
+def test_to_device_no_dtype_preserves_int_and_float_tensors() -> None:
+    """Default behavior (dtype=None) must move tensors without changing dtype."""
+    payload = {
+        "input_ids": torch.arange(4, dtype=torch.long),
+        "image": torch.randn(2, 3, dtype=torch.float32),
+    }
+
+    moved = to_device(payload, device="cpu")
+
+    assert moved["input_ids"].dtype == torch.long
+    assert moved["image"].dtype == torch.float32
+
+
+def test_to_device_dtype_preserves_integer_tensors() -> None:
+    """Regression for issue #36: dtype must not be applied to int tensors."""
+    payload = {
+        "input_ids": torch.arange(4, dtype=torch.long),
+        "attention_mask": torch.ones(4, dtype=torch.long),
+        "pixel_values": torch.randn(2, 3, dtype=torch.float32),
+    }
+
+    moved = to_device(payload, device="cpu", dtype=torch.bfloat16)
+
+    assert moved["input_ids"].dtype == torch.long
+    assert moved["attention_mask"].dtype == torch.long
+    assert moved["pixel_values"].dtype == torch.bfloat16
+
+
+def test_to_device_dtype_preserves_bool_tensors() -> None:
+    """Boolean tensors must keep their dtype even when a float dtype is requested."""
+    mask = torch.tensor([True, False, True])
+
+    moved = to_device(mask, device="cpu", dtype=torch.bfloat16)
+
+    assert moved.dtype == torch.bool
+
+
+def test_to_device_recurses_into_nested_structures() -> None:
+    """Nested mappings and sequences must be walked recursively."""
+    payload = {
+        "tokens": {"input_ids": torch.arange(3, dtype=torch.long)},
+        "frames": [torch.randn(2, dtype=torch.float32) for _ in range(2)],
+    }
+
+    moved = to_device(payload, device="cpu", dtype=torch.bfloat16)
+
+    assert moved["tokens"]["input_ids"].dtype == torch.long
+    assert all(t.dtype == torch.bfloat16 for t in moved["frames"])
+
+
+def test_to_device_passes_through_non_tensor_values() -> None:
+    """Strings, ints, and other non-tensor leaves must be returned unchanged."""
+    payload = {"name": "ego", "id": 7, "tensor": torch.zeros(1)}
+
+    moved = to_device(payload, device="cpu")
+
+    assert moved["name"] == "ego"
+    assert moved["id"] == 7
+    assert torch.equal(moved["tensor"], torch.zeros(1))


### PR DESCRIPTION
## Summary

Fixes #36.

`helper.to_device()` currently casts **every** tensor it encounters to the requested `dtype`. Under mixed-precision inference (e.g. `dtype=torch.bfloat16`), this also rewrites `input_ids` and `attention_mask` from `int64` to `bfloat16`, which then crashes the embedding lookup in the VLM.

This PR restricts the dtype cast to floating-point tensors. Integer and boolean tensors keep their original dtype and are still moved to `device`.

## Behavior

| Caller | `dtype` arg | Before | After |
|---|---|---|---|
| `test_inference.py:52` (`to_device(model_inputs, "cuda")`) | `None` | device-only move | unchanged |
| Mixed-precision call (`to_device(batch, "cuda", torch.bfloat16)`) | non-None | every tensor cast — breaks embedding lookups | floats cast to `bfloat16`; ints/bools preserved |

The reporter (@aniekannn) suggested the same shape of fix in the issue.

## Test plan

- [x] Existing `device`-only call path in `test_inference.py` is unaffected (dtype is `None`, so the original `data.to(device=device)` path is taken).
- [ ] Manual smoke: pass a dict containing a float tensor and an `int64` tensor through `to_device(..., dtype=torch.bfloat16)` and confirm the float is cast and the int stays `int64`.