### PR TITLE
Sync README project-structure tree with on-disk layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ the `num_traj_samples=1` argument to a higher number (Line 60).
 
 ### Interactive notebook
 
-We provide a notebook with similar inference code at `notebook/inference.ipynb`.
+We provide a notebook with similar inference code at `notebooks/inference.ipynb`.
 
 ## Relationship with the Paper
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ alpamayo/
 │   ├── inference.ipynb                  # Example inference notebook
 │   └── inspect_dataset.ipynb            # Dataset inspection notebook
 ├── scripts/
+│   ├── convert_cosmos_rl_checkpoint.py  # Convert Cosmos-RL checkpoints to HF format
+│   ├── convert_release_config_to_training.py  # Adapt release configs for training
+│   ├── curate_pai_samples.py            # Curate PAI clip subsets for RL
 │   └── download_pai.py                  # PhysicalAI-AV dataset downloader
 ├── docs/
 │   └── FINETUNE_SFT.md                  # SFT setup and configuration guide

--- a/README.md
+++ b/README.md
@@ -168,23 +168,33 @@ alpamayo/
 │       ├── models/                      # Trainable wrappers
 │       ├── train_hf.py                  # Training script
 │       └── evaluate_hf.py               # Evaluation script
-├── notebook/
-│   └── inference.ipynb                  # Example notebook
+├── notebooks/
+│   ├── inference.ipynb                  # Example inference notebook
+│   └── inspect_dataset.ipynb            # Dataset inspection notebook
+├── scripts/
+│   └── download_pai.py                  # PhysicalAI-AV dataset downloader
+├── docs/
+│   └── FINETUNE_SFT.md                  # SFT setup and configuration guide
 ├── src/
 │   └── alpamayo_r1/
-│       ├── action_space/
-│       │   └── ...                      # Action space definitions
-│       ├── diffusion/
-│       │   └── ...                      # Diffusion model components
-│       ├── geometry/
-│       │   └── ...                      # Geometry utilities and modules
-│       ├── models/
-│       │   ├── ...                      # Model components and utils functions
+│       ├── action_space/                # Action space definitions
+│       ├── chat_template/               # Conversation building & chat templates
+│       ├── common/                      # Constants, logging, distributed utils
+│       ├── data/                        # PhysicalAI-AV data utilities
+│       ├── diffusion/                   # Diffusion model components
+│       ├── geometry/                    # Geometry utilities and modules
+│       ├── metrics/                     # Trajectory and distance metrics
+│       ├── models/                      # Model components and utils functions
+│       ├── processor/                   # Qwen-VL processor with expanded vocab
+│       ├── utils/                       # Token/label-mask helpers
+│       ├── visualization/               # Trajectory and waypoint visualizers
 │       ├── __init__.py                  # Package marker
 │       ├── config.py                    # Model and experiment configuration
 │       ├── helper.py                    # Utility functions
 │       ├── load_physical_aiavdataset.py # Dataset loader
-│       ├── test_inference.py            # Inference test script
+│       └── test_inference.py            # Inference test script
+├── CONTRIBUTING.md                      # Contribution guidelines
+├── LICENSE                              # License file
 ├── pyproject.toml                       # Project dependencies
 └── uv.lock                              # Locked dependency versions
 ```


### PR DESCRIPTION
## Summary

The README's **Project Structure** section had drifted from what's actually in the repo. As a newcomer reading the README I expected a 1:1 map and found:

- \`notebook/\` should be \`notebooks/\` — the documented singular path doesn't exist.
- \`notebooks/inspect_dataset.ipynb\` was not listed.
- \`scripts/\` (containing \`download_pai.py\`) and \`docs/\` (containing \`FINETUNE_SFT.md\`) were missing entirely.
- \`src/alpamayo_r1/\` only listed 4 of the 11 subpackages. Missing: \`chat_template\`, \`common\`, \`data\`, \`metrics\`, \`processor\`, \`utils\`, \`visualization\`.
- \`CONTRIBUTING.md\` and \`LICENSE\` weren't represented at the top level.

This PR updates the tree to match \`ls\` and adds a one-line description for each previously undocumented subpackage. No code changes, no behavioral changes — pure docs sync.

## Verification

\`\`\`console
\$ ls src/alpamayo_r1/ | grep -v __pycache__
__init__.py  action_space/  chat_template/  common/  config.py  data/
diffusion/  geometry/  helper.py  load_physical_aiavdataset.py  metrics/
models/  processor/  test_inference.py  utils/  visualization/
\`\`\`

The new tree lists all of the above (plus the 11 subpackages) and matches what a newly-cloned working tree shows.

## Test plan

- [x] Every directory and file mentioned in the new tree exists in the repo.
- [x] No dead entries (all paths verified with \`ls\` / \`find\`).
- [ ] Markdown renders without table/tree breakage (visual check on GitHub after push).