### PR TITLE
Sync load_physical_aiavdataset docstring with the code

### DIFF
--- a/src/alpamayo_r1/load_physical_aiavdataset.py
+++ b/src/alpamayo_r1/load_physical_aiavdataset.py
@@ -43,15 +43,19 @@ def load_physical_aiavdataset(
     Args:
         clip_id: The clip ID to load data from. Can be obtained from vla_golden.parquet.
         t0_us: The timestamp (in microseconds) at which to sample the trajectory.
-            If None, uses a timestamp 5.1s seconds into the clip.
+            Defaults to 5_100_000 (5.1 s into the clip). Must be greater than
+            ``num_history_steps * time_step * 1_000_000`` so the full history
+            window fits inside the clip.
         avdi: Optional pre-initialized PhysicalAIAVDatasetInterface. If None, creates one.
         maybe_stream: Whether to stream data from HuggingFace (if not downloaded locally).
         num_history_steps: Number of history trajectory steps (default: 16 for 1.6s at 10Hz).
         num_future_steps: Number of future trajectory steps (default: 64 for 6.4s at 10Hz).
         time_step: Time step between trajectory points in seconds (default: 0.1s = 10Hz).
         camera_features: List of camera features to load. If None, uses 4 cameras:
-            [CAMERA_FRONT_WIDE_120FOV, CAMERA_FRONT_TELE_30FOV,
-             CAMERA_CROSS_LEFT_120FOV, CAMERA_CROSS_RIGHT_120FOV].
+            [CAMERA_CROSS_LEFT_120FOV, CAMERA_FRONT_WIDE_120FOV,
+             CAMERA_CROSS_RIGHT_120FOV, CAMERA_FRONT_TELE_30FOV].
+            The returned ``image_frames`` are sorted by camera index regardless
+            of the order given here.
         num_frames: Number of frames per camera to load (default: 4).
 
     Returns:


### PR DESCRIPTION
## Summary

Two small accuracy issues in the \`load_physical_aiavdataset()\` docstring:

### 1. \`t0_us\` doesn't actually accept None

The doc says:

> \`t0_us\`: The timestamp (in microseconds)... If None, uses a timestamp 5.1s seconds into the clip.

But the signature is \`t0_us: int = 5_100_000\` and there's no None-handling. Passing \`None\` crashes at the precondition check:

\`\`\`python
>>> t0_us = None
>>> t0_us <= 1_500_000  # history_time_range_us for defaults
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
\`\`\`

Updated to describe the actual default (\`5_100_000\`) and surface the implicit precondition (\`t0_us > num_history_steps * time_step * 1_000_000\`).

### 2. Default \`camera_features\` order is misleading

The doc listed the cameras in a different order from the code. Same set of four, just rearranged. Cross-referencing a doc'd order against the code order is needlessly confusing. Updated to match the actual code ordering and added a note that \`image_frames\` is sorted by camera index in the output regardless of the input order — so this argument controls *which* cameras load, not the output sequence.

## Test plan

- [x] No code changes — pure docstring fix.
- [x] \`grep\` confirmed no other places quote the old camera ordering or the "If None" line.

## Out of scope

This doesn't change the parameter annotation to \`int | None\`. If maintainers want the docstring promise honored at the code level instead, I'm happy to swap the fix direction in a follow-up.