### PR TITLE
Replace mutable default list with None sentinel in basic_collation_fn

### DIFF
--- a/src/alpamayo_r1/processor/qwen_processor.py
+++ b/src/alpamayo_r1/processor/qwen_processor.py
@@ -61,14 +61,14 @@ def sort_images_by_camera_ids(
     return tuple(result)
 
 
-def basic_collation_fn(batch, unstackable_keys: list[str] = []):
+def basic_collation_fn(batch, unstackable_keys: list[str] | None = None):
     """Collate function that does torch.stack on the keys that are tensors, and for the other keys
     returns a list.
     """
     stackable = {k: isinstance(v, torch.Tensor) for k, v in batch[0].items()}
 
     # set custom unstackable keys to False
-    for k in unstackable_keys:
+    for k in unstackable_keys or []:
         if k in stackable:
             stackable[k] = False
 


### PR DESCRIPTION
### Problem
`basic_collation_fn` in `src/alpamayo_r1/processor/qwen_processor.py` uses a mutable list as the default for `unstackable_keys`:

```python
def basic_collation_fn(batch, unstackable_keys: list[str] = []):
```

Mutable default arguments are a well-known Python pitfall — the empty list is created once at function-definition time and reused across every call, so any mutation persists across invocations. Even though the current body only iterates over the argument (no mutation today), this pattern is brittle to future edits and is flagged by `ruff B006` / `pylint W0102`.

### Fix
Switch to the standard `list[str] | None = None` pattern and treat `None` as "no extra unstackable keys":

```python
def basic_collation_fn(batch, unstackable_keys: list[str] | None = None):
    ...
    for k in unstackable_keys or []:
        ...
```

Two-line change. Behavior is identical for every call site (the default is still effectively an empty iterable). The function is exposed at module level, so callers passing an explicit list continue to work unchanged.

### Verification
- `unstackable_keys=None` → `None or [] == []` → loop is skipped (matches old behavior).
- `unstackable_keys=["foo"]` → loop runs over `["foo"]` (matches old behavior).
- `unstackable_keys=[]` → loop is skipped (matches old behavior).