### PR TITLE
Fix get_label_mask docstrings and get_assistant_mask return type

### DIFF
--- a/src/alpamayo_r1/utils/get_label_mask.py
+++ b/src/alpamayo_r1/utils/get_label_mask.py
@@ -34,10 +34,13 @@ def fill_masks_between_special_tokens(
         end_token (str): the end token to look for in the input ids.
         input_ids (B, seq_len): tensor of input ids.
         tokenizer (AutoTokenizer): The tokenizer used to convert tokens to ids.
-        labels_mask (B, seq_len): tensor of labels mask, indicating the positions that should
+        labels_mask (B, seq_len): tensor of labels mask, indicating the positions
+            that should be used for computing the loss. Mutated in-place: positions
+            from each ``start_token`` through the matching ``end_token`` (inclusive)
+            are set to ``True``.
 
     Returns:
-        (B, seq_len): updated labels mask.
+        (B, seq_len): the same ``labels_mask`` tensor with the spans filled in.
     """
     start_idx = (input_ids == tokenizer.convert_tokens_to_ids(start_token)).nonzero()
     end_idx = (input_ids == tokenizer.convert_tokens_to_ids(end_token)).nonzero()
@@ -86,7 +89,7 @@ def get_assistant_mask(
     bos_token: str = "<|im_start|>",
     eos_token: str = "<|im_end|>",
     role: str = "assistant",
-) -> torch.Tensor:
+) -> torch.Tensor | list[bool]:
     """Generate a boolean mask indicating which tokens correspond to the assistant's response.
 
     Args:
@@ -97,10 +100,9 @@ def get_assistant_mask(
         role (str, optional): The assistant role string. Defaults to "assistant".
 
     Returns:
-        torch.Tensor: A boolean mask with True for assistant tokens, False otherwise.
-
-    Reference:
-        Adapted from:
+        A boolean mask with ``True`` for assistant tokens, ``False`` otherwise. Returned
+        as a ``torch.Tensor`` when ``tokens`` is a ``torch.Tensor``, or as a ``list[bool]``
+        when ``tokens`` is a ``list[int]``.
     """
     # Offsets: skip the bos + "assistant\n" (always 3 tokens) and include the eos (+1)
     # for supervision


### PR DESCRIPTION
### Problem
Three small accuracy issues in `src/alpamayo_r1/utils/get_label_mask.py`:

1. **Truncated docstring** in `fill_masks_between_special_tokens` — the entry for `labels_mask` cuts off mid-sentence:
   ```
   labels_mask (B, seq_len): tensor of labels mask, indicating the positions that should
   ```
   Readers can't tell what the function actually does to the mask, and the in-place mutation isn't documented.

2. **Wrong return-type annotation** on `get_assistant_mask`. The function declares `-> torch.Tensor`, but the body returns `masks.tolist()` (a `list[bool]`) when `tokens` is a `list[int]`:
   ```python
   if isinstance(tokens, torch.Tensor):
       return torch.from_numpy(masks)
   else:
       return masks.tolist()
   ```
   This trips up type-checkers and is misleading to callers passing a list.

3. **Dangling reference block** in `get_assistant_mask` — the docstring ends with:
   ```
   Reference:
       Adapted from:
   ```
   No URL or citation follows. Either fill it in or drop it; this PR drops it.

### Fix
Pure docstring + annotation hygiene. No behavioral change.

- Complete the truncated `labels_mask` description and note in-place mutation + inclusive end-token semantics (matches the `# NOTE: we should include the end token in the mask` comment that already exists in the body).
- Update `get_assistant_mask` annotation to `torch.Tensor | list[bool]` and reflect this in the docstring.
- Remove the empty `Reference: Adapted from:` block.

### Verification
No code paths changed. Mypy / pyright now agree with the actual runtime types.