### PR TITLE
Sync metric docstrings with the keys actually returned

### DIFF
--- a/src/alpamayo_r1/metrics/distance_metrics.py
+++ b/src/alpamayo_r1/metrics/distance_metrics.py
@@ -72,9 +72,15 @@ def compute_minade(
         time_step (float): Time step of the trajectory.
 
     Returns:
-        dict[str, torch.Tensor]:
-            min_ade: [B], average min_ade over N groups for each batch element
-            min_ade_sq: [B], average squared min_ade over N groups, for each batch element
+        dict[str, torch.Tensor]: keys mapped to per-batch tensors of shape [B]:
+
+            - ``min_ade``: mean min-ADE over the N groups, averaged over all timesteps.
+            - ``min_ade/by_t={H:.1f}``: mean min-ADE over the N groups, averaged over the
+              first ``t`` timesteps for each ``t in timestep_horizons`` that satisfies
+              ``t <= T``. ``H = t * time_step`` is the horizon in seconds.
+            - ``<key>_std``: stdev across the N groups for each of the above keys.
+              Only added when ``N > 1`` and ``disable_summary`` is False
+              (see ``summarize_metric``).
     """
     _, N, _, T, _ = pred_xyz.shape
     # Filter timestep_horizons to only include those that don't exceed available timesteps
@@ -116,9 +122,12 @@ def compute_grouped_corner_distance(
         disable_summary (bool): if True, return corner_distance without summarizing over groups.
 
     Returns:
-        dict[str, torch.Tensor]:
-            corner_distance: [B], average corner distance over N groups
-            corner_distance_sq: [B], average squared corner distance over N groups
+        dict[str, torch.Tensor]: keys mapped to per-batch tensors of shape [B]:
+
+            - ``corner_distance``: mean corner distance over the N groups (after taking
+              the per-group min over the K samples and averaging over T and the 8 corners).
+            - ``corner_distance_std``: stdev across the N groups. Only added when
+              ``N > 1`` and ``disable_summary`` is False (see ``summarize_metric``).
     """
     _, N = pred_xyz.shape[:2]
     corner_pred = coordinates.xyzrot_to_corners(

--- a/src/alpamayo_r1/metrics/metric_utils.py
+++ b/src/alpamayo_r1/metrics/metric_utils.py
@@ -21,18 +21,19 @@ import torch
 def summarize_metric(
     metric: Mapping[str, torch.Tensor], disable_summary: bool = False
 ) -> dict[str, torch.Tensor]:
-    """Replaces dict containing multi-dimensional metrics with mean, mean_square, and stdev.
+    """Replaces dict containing multi-dimensional metrics with mean and (optionally) stdev.
 
     Args:
         metric: dict[str,Tensor]
             name: shape [B, N]
-        disable_summary: bool, if True, return metric without summarizing over groups.
+        disable_summary: bool, if True, return only the per-name mean (no ``_std``
+            entries are added even when N > 1).
 
     Returns:
         dict[str,Tensor]
-            name: shape [B] # average
-            name_sq: shape [B] # average square
-            name_std: shape [B] # standard deviation over N
+            name: shape [B] # mean over the N axis
+            name_std: shape [B] # stdev over the N axis. Only present when
+                N > 1 and ``disable_summary`` is False.
     """
     result = {}
     for metric_name, val in metric.items():


### PR DESCRIPTION
### Problem
The docstrings in `src/alpamayo_r1/metrics/metric_utils.py` and `src/alpamayo_r1/metrics/distance_metrics.py` advertise return-dict keys that are never produced. Anyone iterating these dicts looking for the documented `_sq` keys gets a `KeyError`.

**1. `summarize_metric` (`metric_utils.py`)**

Docstring claims it returns:
```
name: shape [B] # average
name_sq: shape [B] # average square
name_std: shape [B] # standard deviation over N
```
But the body only adds `name_std`:
```python
if val.shape[1] > 1 and not disable_summary:
    mean_sq = val.pow(2).mean(1)
    std = (mean_sq - mean**2).sqrt()
    result[metric_name + "_std"] = std
```
`mean_sq` is computed as an intermediate of `std` and discarded. Also, the gating on `N > 1` is not obvious from the docstring.

**2. `compute_minade` (`distance_metrics.py`)**

Docstring lists `min_ade_sq`, but the body returns `min_ade` plus per-horizon keys of the form `min_ade/by_t={t * time_step:.1f}` (then optionally `_std` variants via `summarize_metric`). The per-horizon keys are the function's headline output and were entirely undocumented.

**3. `compute_grouped_corner_distance` (`distance_metrics.py`)**

Docstring lists `corner_distance_sq`, but the body returns `corner_distance` (and `corner_distance_std` from `summarize_metric` when `N > 1` and `disable_summary=False`).

### Fix
Pure docstring change — no code logic touched. Aligns each docstring with the actual returned keys and documents how `summarize_metric` layers `_std` on top.

### Verification
Skimmed the call sites (none rely on the documented `_sq` keys), and the new wording matches the runtime behavior verifiable by reading the function bodies.