### PR TITLE
Document exclusive-end --chunk range in curate_pai_samples.py

### DIFF
--- a/scripts/curate_pai_samples.py
+++ b/scripts/curate_pai_samples.py
@@ -19,8 +19,11 @@
 example:
 python scripts/curate_pai_samples.py \
   --clip-index-path /path/to/PAI_datset/clip_index.parquet \
-  --chunk 3116-3119 --num-samples 16 \
+  --chunk 3116-3120 --num-samples 16 \
   --output-path /path/to/PAI_datset/clip_index_3116_mini.parquet
+
+Note: --chunk uses the same range semantics as scripts/download_pai.py
+(exclusive end). The example above selects chunks 3116, 3117, 3118, 3119.
 """
 
 import pandas as pd
@@ -43,7 +46,11 @@ def parse_args() -> argparse.Namespace:
         "-c",
         type=str,
         required=True,
-        help="chunk_id(s): single (e.g. 3116), space-separated (e.g. '3116 3117'), or range (e.g. 3116-3119)",
+        help=(
+            "chunk_id(s): single '3116', space-separated '3116 3117', "
+            "or range '3116-3120' (exclusive end, selects 3116,3117,3118,3119). "
+            "Mirrors --chunk-ids semantics in scripts/download_pai.py."
+        ),
     )
     parser.add_argument(
         "--num-samples", "-n", type=int, required=True, help="Number of samples to curate"


### PR DESCRIPTION
### Problem
`scripts/curate_pai_samples.py` and `scripts/download_pai.py` both accept a `start-end` range form for chunk IDs and both implement it as `range(start, end)` (exclusive of `end`).

`download_pai.py` spells this out in its `--chunk-ids` help string:
> `range '0-3' (exclusive end, downloads 0,1,2)`

`curate_pai_samples.py` does **not**, and its docstring example actively misleads:

```python
"""
example:
python scripts/curate_pai_samples.py \\
  --clip-index-path /path/to/PAI_datset/clip_index.parquet \\
  --chunk 3116-3119 --num-samples 16 \\
  ...
"""
```

A user following that example reasonably expects 4 chunks (3116, 3117, 3118, 3119) but silently gets 3 (3116, 3117, 3118), because:

```python
def _parse_chunk_ids(chunk_arg: str) -> list[str]:
    if "-" in chunk_arg:
        start_s, end_s = chunk_arg.split("-", 1)
        start, end = int(start_s.strip()), int(end_s.strip())
        return [str(i) for i in range(start, end)]
```

### Fix
Pure docs / UX change. The `_parse_chunk_ids` implementation is unchanged.

- Update the `--chunk` argparse help to mirror `download_pai.py`'s wording and explicitly call out the exclusive-end behavior, with a cross-reference so the two stay in lockstep.
- Adjust the docstring example from `--chunk 3116-3119` to `--chunk 3116-3120` and add an inline note clarifying that `3120` is excluded. The new example still selects 4 chunks (3116-3119), matching the obvious reading of the original example.

### Verification
No code logic touched. New help text correctly describes existing behavior of `_parse_chunk_ids`.