### PR TITLE
Remove commented-out debug print in QwenProcessor._preprocess_data

### DIFF
--- a/src/alpamayo_r1/processor/qwen_processor.py
+++ b/src/alpamayo_r1/processor/qwen_processor.py
@@ -290,7 +290,6 @@ class QwenProcessor:
             )
             index += 1
         text = text.replace("<|placeholder|>", processor.image_token)
-        # print(index, len(image_inputs["image_grid_thw"]))
         assert index == len(image_inputs["image_grid_thw"])
 
         tokenized_data = {"text": text, **image_inputs}


### PR DESCRIPTION
### Problem
A commented-out debug print was left next to the matching assert in `QwenProcessor._preprocess_data`:

```python
text = text.replace("<|placeholder|>", processor.image_token)
# print(index, len(image_inputs["image_grid_thw"]))
assert index == len(image_inputs["image_grid_thw"])
```

The assert immediately below it already raises with the relevant values when the invariant breaks (Python's standard assertion failure format includes the operands), so the print would not provide any signal a developer can't already get from a normal failure.

### Fix
Delete the commented line. One-line removal, no behavior change.