### PR TITLE
Document exclusive-end chunk_ids range and broaden type annotation in pai_utils

### DIFF
--- a/src/alpamayo_r1/data/pai_utils.py
+++ b/src/alpamayo_r1/data/pai_utils.py
@@ -37,7 +37,7 @@ class PhysicalAIAVDatasetLocalInterface:
     def __init__(
         self,
         local_dir: str | pathlib.Path,
-        chunk_ids: list[int] | None = None,
+        chunk_ids: list[int] | tuple[int, ...] | int | str | None = None,
         features_metadata: str = "features.csv",
         clip_index_metadata: str = "clip_index.parquet",
         start_safe_margin_seconds: float = 1.6,
@@ -47,8 +47,15 @@ class PhysicalAIAVDatasetLocalInterface:
 
         Args:
             local_dir: Path to the local directory containing the PAI dataset.
-            chunk_ids: List of chunk IDs to load, or a range string (e.g. "0-9").
-                      If None, all available chunks will be loaded.
+            chunk_ids: Which chunks to load. Accepted forms:
+
+                - ``None``: load all available chunks.
+                - ``int``: a single chunk id, e.g. ``3``.
+                - ``list[int]`` / ``tuple[int, ...]`` / any other iterable of ints.
+                - ``str`` of the form ``"<start>-<end>"`` with **exclusive end**,
+                  e.g. ``"0-10"`` selects chunks ``0..9``. This matches the
+                  ``--chunk-ids`` semantics in ``scripts/download_pai.py`` and
+                  ``--chunk`` in ``scripts/curate_pai_samples.py``.
         """
         self.local_dir = local_dir
         self.chunk_ids = None


### PR DESCRIPTION
### Problem
`PhysicalAIAVDatasetLocalInterface.__init__` in `src/alpamayo_r1/data/pai_utils.py` accepts a wider variety of `chunk_ids` inputs than its annotation and docstring suggest:

- The annotation is `list[int] | None`, but the body has explicit branches for `str` (range form), `int` (single id), and any iterable. Static checkers reject the documented `"0-9"` range usage outright.

- The docstring reads:
  > `chunk_ids: List of chunk IDs to load, or a range string (e.g. "0-9").`

  …without spelling out whether the end is inclusive. The implementation does `range(chunk_start, chunk_end)`, which is **exclusive** of the end — matching the semantics in `scripts/download_pai.py` (called out explicitly in #81) and `scripts/curate_pai_samples.py` (made explicit in #87). A user reading the example `"0-9"` would reasonably guess "0..9 inclusive" and silently lose chunk 9.

### Fix
Pure docs + annotation. No runtime behavior change.

- Broaden the type hint to `list[int] | tuple[int, ...] | int | str | None`, matching the actual `isinstance` branches in the body.
- Replace the one-line docstring with a bullet list of accepted forms, spell out the exclusive-end semantics with a worked example (`"0-10"` → chunks `0..9`), and cross-reference the two scripts that share the convention so they stay in lockstep with #81 and #87.

### Verification
The new annotation accepts every concrete shape the body's `isinstance` chain handles. Range example matches the existing implementation (`range(chunk_start, chunk_end)`).