### PR TITLE
Add regression tests for basic_collation_fn and get_assistant_mask

### DIFF
--- a/src/alpamayo_r1/processor/test_qwen_processor.py
+++ b/src/alpamayo_r1/processor/test_qwen_processor.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``alpamayo_r1.processor.qwen_processor`` helpers.
+
+Run:
+    pytest src/alpamayo_r1/processor/test_qwen_processor.py -v
+"""
+
+from __future__ import annotations
+
+import torch
+
+from alpamayo_r1.processor.qwen_processor import basic_collation_fn
+
+
+def test_basic_collation_fn_default_unstackable_keys_is_safe() -> None:
+    """Default ``unstackable_keys`` must behave as 'no extra unstackable keys'.
+
+    Regression for the previous mutable-list default. Any caller that omits
+    ``unstackable_keys`` should get a clean stack of every tensor key.
+    """
+    batch = [
+        {"a": torch.zeros(3), "b": torch.ones(2)},
+        {"a": torch.zeros(3), "b": torch.ones(2)},
+    ]
+
+    out = basic_collation_fn(batch)
+
+    assert isinstance(out["a"], torch.Tensor)
+    assert isinstance(out["b"], torch.Tensor)
+    assert out["a"].shape == (2, 3)
+    assert out["b"].shape == (2, 2)
+
+
+def test_basic_collation_fn_explicit_none_unstackable_keys() -> None:
+    """Passing ``unstackable_keys=None`` explicitly is equivalent to omitting it."""
+    batch = [
+        {"a": torch.zeros(3)},
+        {"a": torch.zeros(3)},
+    ]
+
+    out = basic_collation_fn(batch, unstackable_keys=None)
+
+    assert out["a"].shape == (2, 3)
+
+
+def test_basic_collation_fn_marks_keys_as_unstackable() -> None:
+    """Keys named in ``unstackable_keys`` must be returned as a plain list."""
+    batch = [
+        {"a": torch.zeros(3), "image_frames": torch.zeros(1, 2, 3)},
+        {"a": torch.zeros(3), "image_frames": torch.zeros(1, 2, 3)},
+    ]
+
+    out = basic_collation_fn(batch, unstackable_keys=["image_frames"])
+
+    assert isinstance(out["a"], torch.Tensor)
+    assert out["a"].shape == (2, 3)
+    assert isinstance(out["image_frames"], list)
+    assert len(out["image_frames"]) == 2
+
+
+def test_basic_collation_fn_default_does_not_leak_state_between_calls() -> None:
+    """Repeated invocations with the default must not accumulate state.
+
+    The original ``unstackable_keys=[]`` default was a mutable list; this test
+    pins down that switching to ``None`` (or any sentinel) does not regress
+    that behavior even if a future edit accidentally mutates the default.
+    """
+    batch = [{"a": torch.zeros(3)}, {"a": torch.zeros(3)}]
+
+    out_first = basic_collation_fn(batch)
+    out_second = basic_collation_fn(batch)
+
+    assert out_first["a"].shape == (2, 3)
+    assert out_second["a"].shape == (2, 3)
+
+
+def test_basic_collation_fn_non_tensor_values_become_lists() -> None:
+    """Non-tensor values must always be returned as lists, never stacked."""
+    batch = [
+        {"id": "a", "x": torch.zeros(2)},
+        {"id": "b", "x": torch.ones(2)},
+    ]
+
+    out = basic_collation_fn(batch)
+
+    assert out["id"] == ["a", "b"]
+    assert isinstance(out["x"], torch.Tensor)
+    assert out["x"].shape == (2, 2)

--- a/src/alpamayo_r1/utils/test_get_label_mask.py
+++ b/src/alpamayo_r1/utils/test_get_label_mask.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``alpamayo_r1.utils.get_label_mask``.
+
+Run:
+    pytest src/alpamayo_r1/utils/test_get_label_mask.py -v
+"""
+
+from __future__ import annotations
+
+import torch
+
+from alpamayo_r1.utils.get_label_mask import get_assistant_mask
+
+
+class _StubTokenizer:
+    """Minimal tokenizer that satisfies ``convert_tokens_to_ids`` for tests."""
+
+    def __init__(self, mapping: dict[str, int]) -> None:
+        self._mapping = mapping
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self._mapping[token]
+
+
+def _make_tokens() -> tuple[_StubTokenizer, list[int]]:
+    """Build a tokenizer and a token sequence with one assistant turn.
+
+    Layout: [BOS, USER, content, EOS, BOS, ASSISTANT, content, content, EOS]
+    The assistant turn starts at index 4 and ends at index 8.
+    """
+    tokenizer = _StubTokenizer(
+        {
+            "<|im_start|>": 100,
+            "<|im_end|>": 101,
+            "user": 200,
+            "assistant": 201,
+        }
+    )
+    # Indices: 0    1   2  3   4    5   6  7  8
+    tokens = [100, 200, 1, 101, 100, 201, 2, 3, 101]
+    return tokenizer, tokens
+
+
+def test_get_assistant_mask_returns_tensor_for_tensor_input() -> None:
+    tokenizer, tokens = _make_tokens()
+
+    mask = get_assistant_mask(tokenizer, torch.tensor(tokens))
+
+    assert isinstance(mask, torch.Tensor)
+    assert mask.dtype == torch.bool
+    assert mask.shape == (len(tokens),)
+
+
+def test_get_assistant_mask_returns_list_for_list_input() -> None:
+    """When ``tokens`` is a ``list[int]`` the function returns ``list[bool]``."""
+    tokenizer, tokens = _make_tokens()
+
+    mask = get_assistant_mask(tokenizer, tokens)
+
+    assert isinstance(mask, list)
+    assert all(isinstance(v, bool) for v in mask)
+    assert len(mask) == len(tokens)
+
+
+def test_get_assistant_mask_marks_only_assistant_span_inclusive_of_eos() -> None:
+    """Mask must cover the assistant content + the trailing EOS, per the body's
+    ``masks[start + 3 : end + 1] = True`` rule.
+
+    For the layout above (BOS=4, ASSISTANT=5, content=6,7, EOS=8) the span
+    `start + 3 = 7` through `end + 1 = 9` should be True. Index 8 (the EOS)
+    is included; the user turn (indices 0-3) should be False throughout.
+    """
+    tokenizer, tokens = _make_tokens()
+
+    mask = get_assistant_mask(tokenizer, torch.tensor(tokens)).tolist()
+
+    # User turn never marked.
+    assert mask[0:4] == [False, False, False, False]
+    # Assistant header (BOS + role token + newline-equivalent) is skipped.
+    assert mask[4:7] == [False, False, False]
+    # Assistant content + EOS is marked.
+    assert mask[7] is True
+    assert mask[8] is True
+
+
+def test_get_assistant_mask_tensor_and_list_inputs_agree() -> None:
+    """Tensor and list inputs must produce identical boolean values."""
+    tokenizer, tokens = _make_tokens()
+
+    tensor_mask = get_assistant_mask(tokenizer, torch.tensor(tokens))
+    list_mask = get_assistant_mask(tokenizer, tokens)
+
+    assert tensor_mask.tolist() == list_mask


### PR DESCRIPTION
### Why
Two small helpers in the package have public-API contracts that recently had docs/fix PRs land against them:

- `basic_collation_fn` in `src/alpamayo_r1/processor/qwen_processor.py` (the mutable-default-arg fix proposed in #84).
- `get_assistant_mask` in `src/alpamayo_r1/utils/get_label_mask.py` (the return-type/docstring fix proposed in #85).

Without tests, a future edit can quietly regress either contract. This PR follows the same pattern as the to_device tests in #80 — add focused, dependency-light pytest cases that lock in the documented behavior.

### What
**`src/alpamayo_r1/processor/test_qwen_processor.py`** — 5 tests covering `basic_collation_fn`:

- Default arg behaves as "no extra unstackable keys".
- `unstackable_keys=None` is accepted and equivalent to omitting it.
- Keys named in `unstackable_keys` come back as a plain list.
- Repeated calls don't accumulate state via the default arg.
- Non-tensor values are always returned as lists (never stacked).

**`src/alpamayo_r1/utils/test_get_label_mask.py`** — 4 tests covering `get_assistant_mask`:

- `torch.Tensor` input → `torch.Tensor` (bool) output.
- `list[int]` input → `list[bool]` output (the dual return shape the annotation now reflects).
- The mask covers exactly the assistant content + trailing EOS, with the user turn untouched (matches the body's `start+3` / `end+1` logic).
- Tensor and list input paths produce identical booleans.

Tests use a tiny stub tokenizer that only implements `convert_tokens_to_ids`, so they run on CI without HF auth or model downloads.

### Run
```bash
pytest src/alpamayo_r1/processor/test_qwen_processor.py src/alpamayo_r1/utils/test_get_label_mask.py -v
```

### Notes
- These tests pass on the current `main` for the get_assistant_mask file (the fix in #85 was docstring/annotation only; the runtime behavior these tests pin down already exists).
- The collation tests pass on current `main` too — they will also pass after #84 lands, which is the point of a regression test.