### PR TITLE
Fix MetricRunner.run() return-type annotation and document side effect

### DIFF
--- a/src/alpamayo_r1/metrics/metric_runner.py
+++ b/src/alpamayo_r1/metrics/metric_runner.py
@@ -30,8 +30,14 @@ class MetricRunner:
 
     def run(
         self, model: Any, data_batch: dict[str, Any], output_batch: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Run the metrics one-by-one by the order of the metrics list."""
+    ) -> None:
+        """Run the metrics one-by-one in the order of the metrics list.
+
+        Each metric's ``evaluate`` output is collected, prefixed with
+        ``"metric/"``, and merged into ``output_batch`` in-place. Returns
+        ``None``: callers should read the metric values from ``output_batch``
+        after the call.
+        """
         per_sample_metrics = {}
         for metric in self.metrics:
             per_sample = metric.evaluate(model, data_batch, output_batch)


### PR DESCRIPTION
### Problem
`MetricRunner.run` in `src/alpamayo_r1/metrics/metric_runner.py` declares `-> dict[str, Any]` but the body has no `return` statement:

```python
def run(
    self, model: Any, data_batch: dict[str, Any], output_batch: dict[str, Any]
) -> dict[str, Any]:
    """Run the metrics one-by-one by the order of the metrics list."""
    per_sample_metrics = {}
    for metric in self.metrics:
        per_sample = metric.evaluate(model, data_batch, output_batch)
        per_sample_metrics.update(per_sample)

    output_batch.update({"metric/" + k: v for k, v in per_sample_metrics.items()})
```

Python returns `None` implicitly while the annotation lies. This trips up type checkers (`mypy`, `pyright`) and is misleading to callers who reasonably assume they should read a result from the return value.

The actual contract — documented in the class docstring ("…added to the output batch") and matching every existing call site — is to merge the prefixed metrics into `output_batch` in-place.

### Fix
- Change the return annotation from `dict[str, Any]` to `None` so the type matches the runtime behavior.
- Expand the one-line docstring to spell out the in-place mutation contract and explicitly tell callers to read results from `output_batch` after the call.

No runtime behavior change.

### Verification
`grep -A 12 "def run" src/alpamayo_r1/metrics/metric_runner.py` shows the body has no `return` statement; the only side effect is the `output_batch.update(...)` call on the last line.