### PR TITLE
Replace asserts with ValueError in chat_template/conversation.py

### DIFF
--- a/src/alpamayo_r1/chat_template/conversation.py
+++ b/src/alpamayo_r1/chat_template/conversation.py
@@ -35,9 +35,10 @@ def get_component_str(
 
     # if ask this component, we only add start string
     if not ask_for_component:
-        assert (content_str is None) != (padding_str is None), (
-            "Exactly one of content_str or padding_str must be provided"
-        )
+        if (content_str is None) == (padding_str is None):
+            raise ValueError(
+                "Exactly one of content_str or padding_str must be provided"
+            )
         if content_str is not None:
             # add content string directly
             component_str.append(content_str)
@@ -111,8 +112,11 @@ def construct_image(
     Returns:
         image_prompt (list): The list of image description prompts for the VLA model.
     """
-    # assert camera_ids is in ascending order
-    assert torch.all(camera_ids == torch.sort(camera_ids)[0])
+    # camera_ids must be in ascending order (the rest of the function relies on this)
+    if not bool(torch.all(camera_ids == torch.sort(camera_ids)[0])):
+        raise ValueError(
+            f"camera_ids must be sorted in ascending order, got {camera_ids.tolist()}"
+        )
 
     images = data["image_frames"]
     messages = []
@@ -192,7 +196,8 @@ def construct_cot(data: dict[str, Any], ask_for_component: bool = False) -> list
     # if not asking for cot, we must have the cot in data
     cot = None
     if not ask_for_component:
-        assert "cot" in data, "cot not found in data but `cot` in `components_order`"
+        if "cot" not in data:
+            raise ValueError("cot not found in data but `cot` in `components_order`")
         cot = data["cot"]
 
     cot_component = [
@@ -224,9 +229,10 @@ def construct_meta_action(
     # if not asking for meta_action, we must have the meta_action in data
     meta_action = None
     if not ask_for_component:
-        assert "meta_action_strings" in data, (
-            "meta_action not found in data but `meta_action` in `components_order`"
-        )
+        if "meta_action_strings" not in data:
+            raise ValueError(
+                "meta_action not found in data but `meta_action` in `components_order`"
+            )
         meta_action = data["meta_action_strings"]
 
     meta_action_component = [


### PR DESCRIPTION
### Why
Continues the pattern of #50 (`create_message`), #73 (`load_physical_aiavdataset`), and #77 (`assert→ValueError` in public APIs):

> Asserts can be disabled with `python -O` (or `PYTHONOPTIMIZE=1`), so any input-validation guard expressed as an assert silently disappears in optimized runs. Public-API guards must run unconditionally.

`src/alpamayo_r1/chat_template/conversation.py` has four such asserts that all guard caller-provided inputs to public functions. They're invisible to anyone running optimized Python.

### What
Convert all four asserts to explicit `if … raise ValueError(...)`:

| Line | Function | Guarded condition |
|---|---|---|
| 38 | `get_component_str` | exactly one of `content_str` / `padding_str` (XOR) |
| 115 | `construct_image` | `camera_ids` is sorted ascending |
| 195 | `construct_cot` | `"cot"` key present in `data` when not asking the model to generate it |
| 227 | `construct_meta_action` | `"meta_action_strings"` key present in `data` when not asking the model to generate it |

Two readability wins beyond the strip-resistance:

- The XOR check on L38 originally read as `(a is None) != (b is None)`. The new form `if (a is None) == (b is None): raise ValueError(...)` catches both "neither provided" and "both provided" with the same wording — without needing to mentally parse a `!=` of two booleans.
- The `construct_image` check now includes the offending tensor in the error message (`f"got {camera_ids.tolist()}"`), instead of a bare `AssertionError` that hides the value.

### Verification
After this PR, `grep -n "^\s*assert " src/alpamayo_r1/chat_template/conversation.py` returns nothing. Behavior with optimization off is identical; with optimization on, the checks now actually run.