### PR TITLE
Fix viz.py type hints: optional waypoints + rotate_90cc annotations

### DIFF
--- a/src/alpamayo_r1/visualization/viz.py
+++ b/src/alpamayo_r1/visualization/viz.py
@@ -64,8 +64,8 @@ def viz_waypoints_pai(
     intr_df: pd.DataFrame,
     extr_df: pd.DataFrame,
     image,
-    waypoints_gt: np.ndarray,
-    waypoints_pred: np.ndarray,
+    waypoints_gt: np.ndarray | None,
+    waypoints_pred: np.ndarray | None,
 ):
     """Overlay ground-truth and predicted waypoints on the front-wide camera image.
 
@@ -146,8 +146,15 @@ def make_image_grid(images: np.ndarray, columns: int = 4) -> np.ndarray:
     return grid
 
 
-def rotate_90cc(xy):
-    """Rotate 2D coordinates 90 degrees counter-clockwise: (x, y) -> (-y, x)."""
+def rotate_90cc(xy: np.ndarray) -> np.ndarray:
+    """Rotate 2D coordinates 90 degrees counter-clockwise: (x, y) -> (-y, x).
+
+    Args:
+        xy: Array of shape ``(2, N)`` containing the x-row and y-row.
+
+    Returns:
+        Array of shape ``(2, N)`` with the rotated coordinates.
+    """
     return np.stack([-xy[1], xy[0]], axis=0)
 
 


### PR DESCRIPTION
### Problem
Two small type-annotation hygiene nits in `src/alpamayo_r1/visualization/viz.py`:

**1. `viz_waypoints_pai` annotates non-optional but accepts None.**

Signature:
```python
def viz_waypoints_pai(
    intr_df: pd.DataFrame,
    extr_df: pd.DataFrame,
    image,
    waypoints_gt: np.ndarray,
    waypoints_pred: np.ndarray,
):
```

Docstring:
> `waypoints_gt: Ground-truth waypoint tensor, or None to skip.`
> `waypoints_pred: Predicted waypoint tensor, or None to skip.`

Body:
```python
if waypoints_gt is not None: ...
if waypoints_pred is not None: ...
```

Type checkers reject the documented `None` usage outright.

**2. `rotate_90cc` has no annotations.**

```python
def rotate_90cc(xy):
    """Rotate 2D coordinates 90 degrees counter-clockwise: (x, y) -> (-y, x)."""
    return np.stack([-xy[1], xy[0]], axis=0)
```

The neighboring `make_image_grid` is fully annotated; `rotate_90cc` is the odd one out.

### Fix
Pure typing/docstring change. No runtime behavior change.

- Update `viz_waypoints_pai` parameters to `np.ndarray | None`.
- Annotate `rotate_90cc` as `xy: np.ndarray -> np.ndarray` and add a short Args/Returns block noting the expected `(2, N)` shape.