### PR TITLE
Type-fix init_wandb key parameter and _save_wandb_id return

### DIFF
--- a/src/alpamayo_r1/common/wandb_utils.py
+++ b/src/alpamayo_r1/common/wandb_utils.py
@@ -26,7 +26,7 @@ logger.setLevel("INFO")
 
 @distributed.rank_zero_only
 def init_wandb(
-    key: str,
+    key: str | None,
     team: str,
     project: str,
     group: str,
@@ -34,7 +34,20 @@ def init_wandb(
     output_dir: str,
     **kwargs,
 ) -> None:
-    """Initialize wandb."""
+    """Initialize wandb.
+
+    Args:
+        key: W&B API key. If ``None``, ``wandb.login`` is skipped and the
+            credentials cached in the user's home directory are used instead.
+        team: W&B entity (team) name.
+        project: W&B project name.
+        group: W&B run group.
+        name: W&B run name.
+        output_dir: Directory used for run config (``config.yaml``) and the
+            persisted run id (``.wandb_id``); also passed to ``wandb.init`` as
+            its working dir.
+        **kwargs: Forwarded to ``wandb.init``.
+    """
     if key is not None:
         # login wandb, otherwise it will load from the home directory
         wandb.login(key=key)
@@ -68,7 +81,7 @@ def init_wandb(
     )
 
 
-def _save_wandb_id(output_dir: str, wandb_id: str):
+def _save_wandb_id(output_dir: str, wandb_id: str) -> None:
     """Save the wandb id to the output_dir."""
     wandb_id_path = os.path.join(output_dir, ".wandb_id")
     with open(wandb_id_path, "w") as f:


### PR DESCRIPTION
### Problem
Two small typing nits in `src/alpamayo_r1/common/wandb_utils.py`:

**1. `init_wandb` declares `key: str` but accepts None.**

```python
def init_wandb(
    key: str,
    ...
) -> None:
    """Initialize wandb."""
    if key is not None:
        # login wandb, otherwise it will load from the home directory
        wandb.login(key=key)
```

The body explicitly branches on `if key is not None` and the inline comment ("otherwise it will load from the home directory") describes the `None` case as the supported "use cached credentials" path. Type checkers flag any `init_wandb(None, ...)` call site even though that's documented behavior.

**2. `_save_wandb_id` has no return annotation.**

```python
def _save_wandb_id(output_dir: str, wandb_id: str):
    """Save the wandb id to the output_dir."""
```

It returns `None`. The neighboring `_check_wandb_id` is fully annotated (`-> str | None`); `_save_wandb_id` is the odd one out.

### Fix
Pure typing/docstring change. No runtime behavior change.

- Update `init_wandb` parameter annotation to `key: str | None`.
- Expand the `init_wandb` one-word docstring into an Args block — the function is called from external launchers and was previously self-documenting only via parameter names.
- Add `-> None` to `_save_wandb_id`.