### PR TITLE
Remove dead misplaced shebang from convert_release_config_to_training.py

### DIFF
--- a/scripts/convert_release_config_to_training.py
+++ b/scripts/convert_release_config_to_training.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python3
 r"""Convert nvidia/Alpamayo-R1-10B or nvidia/Alpamayo-1.5-10B into a RL training compatible format.
 
 This script downloads the HuggingFace releases, converts the config,


### PR DESCRIPTION
### Problem
`scripts/convert_release_config_to_training.py` has a shebang on **line 16**, after the SPDX header:

```python
# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
# SPDX-License-Identifier: Apache-2.0
#
# Licensed under the Apache License, Version 2.0 (the "License");
... (12 more license lines) ...
# See the License for the specific language governing permissions and
# limitations under the License.

#!/usr/bin/env python3      <-- line 16, ineffective
r"""Convert nvidia/Alpamayo-R1-10B ...
```

A shebang only works as the **very first line** of a file. On line 16 it's just an inert comment the kernel never sees, so even `chmod +x` + `./script.py` would not work as the line implies.

### Fix
Two reasonable options existed:

1. Hoist the shebang to line 1 (and rearrange the SPDX block beneath it).
2. Delete the shebang.

I chose **(2)** because:

- The other three scripts in `scripts/` (`download_pai.py`, `curate_pai_samples.py`, `convert_cosmos_rl_checkpoint.py`) have **no shebang at all** — verified by `grep -n '^#!' scripts/*.py`.
- The file is shipped without the executable bit (`-rw-r--r--`).
- The script's own usage block invokes it as `python scripts/convert_release_config_to_training.py ...`, never `./scripts/...`.

Dropping the line matches the dir convention, removes a misleading marker, and keeps the SPDX header at the canonical position (line 1).

### Verification
After this PR, `grep -n '^#!' scripts/*.py` returns nothing across the entire scripts directory. The script continues to be invoked exactly as documented.