### PR TITLE
Fix launch_alpamayo_model docstring: ckpt source is --config arg, not env var

### DIFF
--- a/finetune/rl/launcher.py
+++ b/finetune/rl/launcher.py
@@ -47,9 +47,11 @@ def launch_alpamayo_model(spec, ckpt_path: str | None = None) -> None:
 
     Args:
         spec: A ``ModelSpec`` instance describing the model components.
-        ckpt_path: Checkpoint path for data/tokenizer init.  If ``None``,
+        ckpt_path: Checkpoint path for data/tokenizer init. If ``None``,
             reads ``[policy].model_name_or_path`` from the TOML config
-            pointed to by the ``COSMOS_CONFIG`` env var.
+            whose path is passed as ``--config <path>`` in ``sys.argv``
+            (the Cosmos ``launch_replica.sh`` wrapper sets this
+            automatically). See ``_read_ckpt_path_from_toml``.
     """
     from cosmos_rl.launcher.worker_entry import main as launch_worker
     from cosmos_rl.policy.model.base import ModelRegistry


### PR DESCRIPTION
### Problem
`launch_alpamayo_model` in `finetune/rl/launcher.py` documents the fallback for `ckpt_path=None` as:

```
ckpt_path: Checkpoint path for data/tokenizer init.  If ``None``,
    reads ``[policy].model_name_or_path`` from the TOML config
    pointed to by the ``COSMOS_CONFIG`` env var.
```

But the actual implementation in `_read_ckpt_path_from_toml` (same file, lines 21–42) does no such thing — it scans `sys.argv` for the literal `--config <path>` argument pair that the Cosmos `launch_replica.sh` wrapper passes:

```python
for i, arg in enumerate(sys.argv):
    if arg == "--config" and i + 1 < len(sys.argv):
        toml_path = sys.argv[i + 1]
        break

if not toml_path:
    raise RuntimeError(
        "No --config <path> found in sys.argv. "
        "The Cosmos orchestrator should pass --config automatically."
    )
```

There is no `os.environ` lookup anywhere in the file — `COSMOS_CONFIG` isn't read at all. A user trying to set `COSMOS_CONFIG=/path/to.toml` and call `launch_alpamayo_model(spec)` would hit the `RuntimeError("No --config <path> found in sys.argv")` instead.

### Fix
Pure docs change. No runtime behavior change.

- Describe the actual source (`--config <path>` in `sys.argv`, set by `launch_replica.sh`).
- Cross-reference `_read_ckpt_path_from_toml` so the docstring stays anchored to the implementation.
- Drop a stray double space before "If".

### Verification
`grep -n COSMOS_CONFIG finetune/rl/launcher.py` returns nothing after this PR — confirming the env var was never read.