### PR TITLE
Use dim= instead of axis= in comfort_reward._within_bound

### DIFF
--- a/finetune/rl/rewards/comfort_reward.py
+++ b/finetune/rl/rewards/comfort_reward.py
@@ -69,7 +69,7 @@ def _within_bound(
     min_bound = min_bound if min_bound is not None else -float("inf")
     max_bound = max_bound if max_bound is not None else float("inf")
     metric_within_bound = (metric > min_bound) & (metric < max_bound)
-    return torch.all(metric_within_bound, axis=-1).float()
+    return torch.all(metric_within_bound, dim=-1).float()
 
 
 def gather_dynamics(


### PR DESCRIPTION
### Problem
`_within_bound` in `finetune/rl/rewards/comfort_reward.py` is the only spot in the file that uses NumPy-style `axis=` rather than PyTorch's `dim=`:

```python
return torch.all(metric_within_bound, axis=-1).float()
```

Every other reduction in the same file uses the PyTorch-idiomatic `dim=`:

| Line | Call |
|---|---|
| 47, 49 | `delta = tensor[..., 1:] - tensor[..., :-1]` (slicing, fine) |
| 54 | `torch.diff(yaw, dim=-1)` |
| 91 | `torch.linalg.norm(..., dim=-1)` |
| 128 | `_within_bound(...).mean(2)` (positional dim) |
| 131 | `comfort_metric_dict[name].mean(dim=-1)` |

PyTorch accepts `axis=` as a deprecated alias for `dim=`, so the call still works — this is purely a consistency fix.

### Fix
One-character change: `axis=-1` → `dim=-1`. Semantics are identical (`torch.all(x, axis=-1) == torch.all(x, dim=-1)`).

### Verification
After the change: `grep -n "axis=" finetune/rl/rewards/comfort_reward.py` returns nothing.