### PR TITLE
Add CLI flags to test_inference.py without changing default behavior

### DIFF
--- a/src/alpamayo_r1/test_inference.py
+++ b/src/alpamayo_r1/test_inference.py
@@ -13,65 +13,179 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# End-to-end example script for the inference pipeline:
-# This script loads a dataset, runs inference, and computes the minADE.
-# It can be used to test the inference pipeline.
+"""End-to-end example script for the inference pipeline.
 
-import torch
+Loads a dataset, runs inference, and computes the minADE. With no arguments
+it reproduces the prior hardcoded behavior exactly; flags exist so users can
+vary the clip, sampling parameters, model name, seed, etc. without editing
+this file.
+
+Examples:
+    # Default behavior (matches the pre-CLI script).
+    python src/alpamayo_r1/test_inference.py
+
+    # Different clip with 8 samples.
+    python src/alpamayo_r1/test_inference.py \\
+        --clip-id 030c760c-ae38-49aa-9ad8-f5650a545d26 --num-traj-samples 8
+
+    # Hotter sampling at a different keyframe.
+    python src/alpamayo_r1/test_inference.py --t0-us 6000000 --temperature 0.9
+"""
+
+from __future__ import annotations
+
+import argparse
+
 import numpy as np
+import torch
 
-from alpamayo_r1.models.alpamayo_r1 import AlpamayoR1
-from alpamayo_r1.load_physical_aiavdataset import load_physical_aiavdataset
 from alpamayo_r1 import helper
+from alpamayo_r1.load_physical_aiavdataset import load_physical_aiavdataset
+from alpamayo_r1.models.alpamayo_r1 import AlpamayoR1
 
 
-# Example clip ID
-clip_id = "030c760c-ae38-49aa-9ad8-f5650a545d26"
-print(f"Loading dataset for clip_id: {clip_id}...")
-data = load_physical_aiavdataset(clip_id, t0_us=5_100_000)
-print("Dataset loaded.")
-messages = helper.create_message(data["image_frames"].flatten(0, 1))
+# Defaults preserve the pre-CLI hardcoded behavior.
+DEFAULT_CLIP_ID = "030c760c-ae38-49aa-9ad8-f5650a545d26"
+DEFAULT_T0_US = 5_100_000
+DEFAULT_MODEL = "nvidia/Alpamayo-R1-10B"
+DEFAULT_NUM_TRAJ_SAMPLES = 1
+DEFAULT_TOP_P = 0.98
+DEFAULT_TEMPERATURE = 0.6
+DEFAULT_MAX_GENERATION_LENGTH = 256
+DEFAULT_SEED = 42
 
-model = AlpamayoR1.from_pretrained("nvidia/Alpamayo-R1-10B", dtype=torch.bfloat16).to("cuda")
-processor = helper.get_processor(model.tokenizer)
-
-inputs = processor.apply_chat_template(
-    messages,
-    tokenize=True,
-    add_generation_prompt=False,
-    continue_final_message=True,
-    return_dict=True,
-    return_tensors="pt",
-)
-model_inputs = {
-    "tokenized_data": inputs,
-    "ego_history_xyz": data["ego_history_xyz"],
-    "ego_history_rot": data["ego_history_rot"],
+DTYPE_MAP: dict[str, torch.dtype] = {
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+    "float32": torch.float32,
 }
 
-model_inputs = helper.to_device(model_inputs, "cuda")
 
-torch.cuda.manual_seed_all(42)
-with torch.autocast("cuda", dtype=torch.bfloat16):
-    pred_xyz, pred_rot, extra = model.sample_trajectories_from_data_with_vlm_rollout(
-        data=model_inputs,
-        top_p=0.98,
-        temperature=0.6,
-        num_traj_samples=1,  # Feel free to raise this for more output trajectories and CoC traces.
-        max_generation_length=256,
-        return_extra=True,
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments. Defaults reproduce the prior hardcoded behavior."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Alpamayo end-to-end inference on a single PAI clip and report minADE."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--clip-id",
+        type=str,
+        default=DEFAULT_CLIP_ID,
+        help="PAI clip id to load.",
+    )
+    parser.add_argument(
+        "--t0-us",
+        type=int,
+        default=DEFAULT_T0_US,
+        help="Keyframe timestamp in microseconds.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL,
+        help="HuggingFace model id (or local path) for AlpamayoR1.from_pretrained.",
+    )
+    parser.add_argument(
+        "--num-traj-samples",
+        type=int,
+        default=DEFAULT_NUM_TRAJ_SAMPLES,
+        help="Number of trajectory samples per CoC rollout. Higher = more variety + memory.",
+    )
+    parser.add_argument(
+        "--top-p",
+        type=float,
+        default=DEFAULT_TOP_P,
+        help="Nucleus sampling probability.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=DEFAULT_TEMPERATURE,
+        help="Sampling temperature.",
+    )
+    parser.add_argument(
+        "--max-generation-length",
+        type=int,
+        default=DEFAULT_MAX_GENERATION_LENGTH,
+        help="Maximum number of generated tokens for the chain-of-causation rollout.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="CUDA RNG seed for reproducibility.",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Torch device for model + inputs (e.g. cuda, cuda:1).",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=sorted(DTYPE_MAP.keys()),
+        default="bfloat16",
+        help="Model dtype + autocast dtype.",
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    """Run inference on a single clip and print minADE."""
+    dtype = DTYPE_MAP[args.dtype]
+
+    print(f"Loading dataset for clip_id: {args.clip_id}...")
+    data = load_physical_aiavdataset(args.clip_id, t0_us=args.t0_us)
+    print("Dataset loaded.")
+
+    messages = helper.create_message(data["image_frames"].flatten(0, 1))
+
+    model = AlpamayoR1.from_pretrained(args.model, dtype=dtype).to(args.device)
+    processor = helper.get_processor(model.tokenizer)
+
+    inputs = processor.apply_chat_template(
+        messages,
+        tokenize=True,
+        add_generation_prompt=False,
+        continue_final_message=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+    model_inputs = {
+        "tokenized_data": inputs,
+        "ego_history_xyz": data["ego_history_xyz"],
+        "ego_history_rot": data["ego_history_rot"],
+    }
+    model_inputs = helper.to_device(model_inputs, args.device)
+
+    torch.cuda.manual_seed_all(args.seed)
+    with torch.autocast(args.device.split(":")[0], dtype=dtype):
+        pred_xyz, pred_rot, extra = model.sample_trajectories_from_data_with_vlm_rollout(
+            data=model_inputs,
+            top_p=args.top_p,
+            temperature=args.temperature,
+            num_traj_samples=args.num_traj_samples,
+            max_generation_length=args.max_generation_length,
+            return_extra=True,
+        )
+
+    # the size is [batch_size, num_traj_sets, num_traj_samples]
+    print("Chain-of-Causation (per trajectory):\n", extra["cot"][0])
+
+    gt_xy = data["ego_future_xyz"].cpu()[0, 0, :, :2].T.numpy()
+    pred_xy = pred_xyz.cpu().numpy()[0, 0, :, :, :2].transpose(0, 2, 1)
+    diff = np.linalg.norm(pred_xy - gt_xy[None, ...], axis=1).mean(-1)
+    min_ade = diff.min()
+    print("minADE:", min_ade, "meters")
+    print(
+        "Note: VLA-reasoning models produce nondeterministic outputs due to trajectory sampling, "
+        "hardware differences, etc. With num_traj_samples=1 (set for GPU memory compatibility), "
+        "variance in minADE is expected. For visual sanity checks, see notebooks/inference.ipynb"
     )
 
-# the size is [batch_size, num_traj_sets, num_traj_samples]
-print("Chain-of-Causation (per trajectory):\n", extra["cot"][0])
 
-gt_xy = data["ego_future_xyz"].cpu()[0, 0, :, :2].T.numpy()
-pred_xy = pred_xyz.cpu().numpy()[0, 0, :, :, :2].transpose(0, 2, 1)
-diff = np.linalg.norm(pred_xy - gt_xy[None, ...], axis=1).mean(-1)
-min_ade = diff.min()
-print("minADE:", min_ade, "meters")
-print(
-    "Note: VLA-reasoning models produce nondeterministic outputs due to trajectory sampling, "
-    "hardware differences, etc. With num_traj_samples=1 (set for GPU memory compatibility), "
-    "variance in minADE is expected. For visual sanity checks, see notebooks/inference.ipynb"
-)
+if __name__ == "__main__":
+    main(parse_args())


### PR DESCRIPTION
### Why
`src/alpamayo_r1/test_inference.py` is the script users run first when trying out the model. Today every parameter — clip id, keyframe, sampling temperature, sample count, model name, seed, device, dtype — is a hardcoded literal at module top level. Anyone who wants to:

- try a different clip
- bump `num_traj_samples` from 1 to 4 to see CoC variation
- swap `nvidia/Alpamayo-R1-10B` for a local checkpoint
- run with `--seed` for a side-by-side comparison
- evaluate at fp16/fp32 instead of bf16

…has to copy the file out, edit constants, re-run, repeat. That's the most common iteration loop in the issues thread.

### What
Wrap the existing top-level body in `parse_args()` + `main(args)` + `if __name__ == "__main__"` and surface the existing constants as CLI flags. **All defaults preserve the current behavior exactly**, so `python src/alpamayo_r1/test_inference.py` produces the same output as before this PR.

New flags (all default to the previous hardcoded values):

| Flag | Default | Purpose |
|---|---|---|
| `--clip-id` | `030c760c-...` | PAI clip id |
| `--t0-us` | `5_100_000` | Keyframe timestamp |
| `--model` | `nvidia/Alpamayo-R1-10B` | HF model id or local path |
| `--num-traj-samples` | `1` | Samples per CoC rollout |
| `--top-p` | `0.98` | Nucleus sampling |
| `--temperature` | `0.6` | Sampling temperature |
| `--max-generation-length` | `256` | CoC token budget |
| `--seed` | `42` | CUDA RNG seed |
| `--device` | `cuda` | Torch device (e.g. `cuda:1`) |
| `--dtype` | `bfloat16` | Choices: `bfloat16`, `float16`, `float32` |

Examples added to the module docstring:

```bash
python src/alpamayo_r1/test_inference.py
python src/alpamayo_r1/test_inference.py --num-traj-samples 8 --temperature 0.9
python src/alpamayo_r1/test_inference.py --t0-us 6000000 --clip-id <other-clip>
```

The trailing operational note about nondeterministic outputs at `num_traj_samples=1` is preserved verbatim.

### Verification
Validated locally without GPU/HF (no model load required) by extracting `parse_args` via AST and asserting:

1. **Defaults match the prior hardcoded values** for every parameter (clip_id, t0_us, model, num_traj_samples, top_p, temperature, max_generation_length, seed, device, dtype).
2. **Overrides take effect**: passing `--num-traj-samples 8 --temperature 0.9 --seed 7` updates exactly those fields and leaves the rest at their defaults.
3. **Invalid `--dtype` is rejected** by `argparse` `choices=` (e.g. `--dtype invalid` exits with `invalid choice: 'invalid'`).

### Migration
Zero migration needed. Existing scripts/CI/notebooks calling `python src/alpamayo_r1/test_inference.py` continue to behave identically.