### PR TITLE
Add trajectory smoothness metrics for evaluation

### DIFF
--- a/src/alpamayo_r1/metrics/smoothness_metrics.py
+++ b/src/alpamayo_r1/metrics/smoothness_metrics.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trajectory smoothness metrics for evaluating predicted ego trajectories.
+
+These metrics measure how comfortable / kinematically plausible a predicted
+trajectory is, independent of how close it is to the ground truth. ADE and
+FDE answer "is the trajectory accurate?"; the metrics here answer "is the
+trajectory drivable?".
+
+Each metric is reported as both a per-batch RMS (overall magnitude) and a
+per-batch absolute max (worst peak). All metrics work on planar XY motion
+plus yaw and assume a fixed planning frequency.
+
+Note on duplication with ``alpamayo_r1.finetune.rl.rewards.comfort_reward``:
+the RL reward turns these dynamics into within-bound booleans for use as a
+training signal. This module reports the actual physical magnitudes for
+post-hoc evaluation. The two share the same kinematic derivations but serve
+different purposes; we keep the math here standalone to avoid a metrics ->
+RL dependency.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from alpamayo_r1.metrics.metric_utils import summarize_metric
+
+
+def _diff_pad_last(tensor: torch.Tensor, freq_hz: float) -> torch.Tensor:
+    """Forward finite difference, padded by repeating the last delta.
+
+    Returns a tensor with the same shape as ``tensor``, scaled by ``freq_hz``.
+    Padding the last delta keeps the output length identical to the input
+    length, which matches the convention used by ``comfort_reward.gather_dynamics``.
+    """
+    delta = tensor[..., 1:] - tensor[..., :-1]
+    last = delta[..., -1:].clone()
+    return torch.cat([delta, last], dim=-1) * freq_hz
+
+
+def _diff_yaw_pad_last(yaw: torch.Tensor, freq_hz: float) -> torch.Tensor:
+    """Forward finite difference of yaw, handling wraparound at +/- pi."""
+    diff = torch.diff(yaw, dim=-1)
+    diff = torch.where(diff > torch.pi, diff - 2 * torch.pi, diff)
+    diff = torch.where(diff < -torch.pi, diff + 2 * torch.pi, diff)
+    rate = diff * freq_hz
+    last = rate[..., -1:].clone()
+    return torch.cat((rate, last), dim=-1)
+
+
+def gather_dynamics(
+    pred_xyz: torch.Tensor,
+    pred_rot: torch.Tensor,
+    planning_freq_hz: float = 10.0,
+) -> dict[str, torch.Tensor]:
+    """Derive ego dynamics from a predicted trajectory.
+
+    Args:
+        pred_xyz: [..., T, 3] positions in the ego frame.
+        pred_rot: [..., T, 3, 3] rotation matrices.
+        planning_freq_hz: Inverse of the time step between samples (default 10 Hz,
+            matching the model's standard 0.1 s output cadence).
+
+    Returns:
+        Dict of [..., T] tensors:
+
+            - ``yaw_rate``         (rad/s)
+            - ``yaw_accel``        (rad/s^2)
+            - ``v_lon``            (m/s, along ego heading)
+            - ``v_lat``            (m/s, perpendicular to ego heading)
+            - ``accel_lon``        (m/s^2, longitudinal)
+            - ``accel_lat``        (m/s^2, lateral)
+            - ``jerk_lon``         (m/s^3, longitudinal)
+    """
+    ego_x = pred_xyz[..., 0]
+    ego_y = pred_xyz[..., 1]
+    ego_h = torch.atan2(pred_rot[..., 1, 0], pred_rot[..., 0, 0])
+
+    dx = _diff_pad_last(ego_x, planning_freq_hz)
+    dy = _diff_pad_last(ego_y, planning_freq_hz)
+    yaw_rate = _diff_yaw_pad_last(ego_h, planning_freq_hz)
+    yaw_accel = _diff_pad_last(yaw_rate, planning_freq_hz)
+
+    v_lon = dx * torch.cos(ego_h) + dy * torch.sin(ego_h)
+    v_lat = -dx * torch.sin(ego_h) + dy * torch.cos(ego_h)
+    accel_lon = _diff_pad_last(v_lon, planning_freq_hz)
+    accel_lat = _diff_pad_last(v_lat, planning_freq_hz)
+    jerk_lon = _diff_pad_last(accel_lon, planning_freq_hz)
+
+    return {
+        "yaw_rate": yaw_rate,
+        "yaw_accel": yaw_accel,
+        "v_lon": v_lon,
+        "v_lat": v_lat,
+        "accel_lon": accel_lon,
+        "accel_lat": accel_lat,
+        "jerk_lon": jerk_lon,
+    }
+
+
+# Which dynamics to summarize as smoothness signals. Each entry maps a
+# user-facing prefix to the ``gather_dynamics`` key it summarizes.
+_SMOOTHNESS_SOURCES: dict[str, str] = {
+    "smoothness/jerk_lon": "jerk_lon",
+    "smoothness/accel_lon": "accel_lon",
+    "smoothness/accel_lat": "accel_lat",
+    "smoothness/yaw_rate": "yaw_rate",
+    "smoothness/yaw_accel": "yaw_accel",
+}
+
+
+def compute_smoothness_metrics(
+    pred_xyz: torch.Tensor,
+    pred_rot: torch.Tensor,
+    disable_summary: bool = False,
+    planning_freq_hz: float = 10.0,
+) -> dict[str, torch.Tensor]:
+    """Compute trajectory smoothness metrics over the standard alpamayo shapes.
+
+    For each kinematic signal (longitudinal/lateral acceleration, longitudinal
+    jerk, yaw rate, yaw acceleration) report two per-batch numbers:
+
+        - ``<name>_rms``  -- RMS magnitude across the trajectory (typical signal level)
+        - ``<name>_max``  -- absolute peak magnitude across the trajectory (worst case)
+
+    Each is averaged over the K samples per group (so a noisy single sample
+    does not dominate) and then summarized over the N groups via
+    ``summarize_metric`` (adds ``_std`` keys when N > 1).
+
+    Args:
+        pred_xyz: [B, N, K, T, 3] predicted ego positions.
+        pred_rot: [B, N, K, T, 3, 3] predicted ego rotations.
+        disable_summary: if True, skip the N-group summarization (no ``_std`` keys).
+        planning_freq_hz: Inverse time step between samples (default 10 Hz).
+
+    Returns:
+        dict[str, torch.Tensor] of [B] tensors. Keys are
+        ``smoothness/{jerk_lon,accel_lon,accel_lat,yaw_rate,yaw_accel}_{rms,max}``,
+        plus ``_std`` variants when N > 1 and ``disable_summary`` is False.
+    """
+    if pred_xyz.ndim != 5 or pred_xyz.shape[-1] != 3:
+        raise ValueError(
+            f"pred_xyz must have shape [B, N, K, T, 3], got {tuple(pred_xyz.shape)}"
+        )
+    if pred_rot.ndim != 6 or pred_rot.shape[-2:] != (3, 3):
+        raise ValueError(
+            f"pred_rot must have shape [B, N, K, T, 3, 3], got {tuple(pred_rot.shape)}"
+        )
+    if pred_xyz.shape[:-1] != pred_rot.shape[:-2]:
+        raise ValueError(
+            f"pred_xyz and pred_rot leading dims must match: "
+            f"{tuple(pred_xyz.shape[:-1])} vs {tuple(pred_rot.shape[:-2])}"
+        )
+
+    dynamics = gather_dynamics(pred_xyz, pred_rot, planning_freq_hz=planning_freq_hz)
+
+    out: dict[str, torch.Tensor] = {}
+    for prefix, src_key in _SMOOTHNESS_SOURCES.items():
+        signal = dynamics[src_key]  # [B, N, K, T]
+        rms = signal.pow(2).mean(dim=-1).sqrt()  # [B, N, K]
+        peak = signal.abs().amax(dim=-1)  # [B, N, K]
+        # Aggregate K -> [B, N] by averaging (worst-K is reported elsewhere via
+        # _max already; here we want a representative per-sample value).
+        out[f"{prefix}_rms"] = rms.mean(dim=2)
+        out[f"{prefix}_max"] = peak.mean(dim=2)
+
+    return summarize_metric(out, disable_summary)

--- a/src/alpamayo_r1/metrics/test_smoothness_metrics.py
+++ b/src/alpamayo_r1/metrics/test_smoothness_metrics.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for smoothness_metrics.
+
+Run:
+    pytest src/alpamayo_r1/metrics/test_smoothness_metrics.py -v
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from alpamayo_r1.metrics.smoothness_metrics import (
+    _SMOOTHNESS_SOURCES,
+    compute_smoothness_metrics,
+    gather_dynamics,
+)
+
+
+def _identity_rot(*shape: int, dtype: torch.dtype = torch.float64) -> torch.Tensor:
+    """Return identity rotation matrices broadcast to the requested batch shape."""
+    return torch.eye(3, dtype=dtype).expand(*shape, 3, 3).contiguous()
+
+
+def _make_constant_velocity(
+    B: int = 2, N: int = 3, K: int = 4, T: int = 16, vx: float = 5.0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Constant straight-line motion at vx m/s, identity heading.
+
+    A constant-velocity trajectory should have zero acceleration, zero jerk,
+    zero lateral motion and zero yaw rate -- everything except v_lon should
+    be (numerically) zero. Uses float64 so finite-difference noise stays at
+    machine precision instead of the ~1e-4 float32 noise that twice-
+    differentiating a 0.1 s step accumulates.
+    """
+    t = torch.arange(T, dtype=torch.float64) * 0.1
+    x = vx * t
+    pred_xyz = torch.zeros(B, N, K, T, 3, dtype=torch.float64)
+    pred_xyz[..., 0] = x
+    pred_rot = _identity_rot(B, N, K, T)
+    return pred_xyz, pred_rot
+
+
+def _make_constant_accel(
+    B: int = 1, N: int = 1, K: int = 1, T: int = 20, ax: float = 2.0
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Constant longitudinal acceleration ax m/s^2 from rest, identity heading.
+
+    Longitudinal accel should be ~ax everywhere; lateral / yaw signals zero.
+    """
+    dt = 0.1
+    t = torch.arange(T, dtype=torch.float64) * dt
+    x = 0.5 * ax * t * t
+    pred_xyz = torch.zeros(B, N, K, T, 3, dtype=torch.float64)
+    pred_xyz[..., 0] = x
+    pred_rot = _identity_rot(B, N, K, T)
+    return pred_xyz, pred_rot
+
+
+def test_gather_dynamics_returns_expected_keys_and_shapes() -> None:
+    pred_xyz, pred_rot = _make_constant_velocity()
+    dyn = gather_dynamics(pred_xyz, pred_rot)
+    expected = {
+        "yaw_rate", "yaw_accel", "v_lon", "v_lat",
+        "accel_lon", "accel_lat", "jerk_lon",
+    }
+    assert set(dyn.keys()) == expected
+    for k, v in dyn.items():
+        assert v.shape == pred_xyz.shape[:-1], f"{k}: {v.shape}"
+
+
+def test_constant_velocity_has_zero_accel_jerk_yaw() -> None:
+    pred_xyz, pred_rot = _make_constant_velocity(vx=5.0)
+    dyn = gather_dynamics(pred_xyz, pred_rot)
+
+    # v_lon should be ~5 m/s everywhere.
+    assert torch.allclose(dyn["v_lon"], torch.full_like(dyn["v_lon"], 5.0), atol=1e-4)
+    # All derived signals should be (numerically) zero.
+    for k in ("v_lat", "accel_lon", "accel_lat", "jerk_lon", "yaw_rate", "yaw_accel"):
+        assert torch.allclose(dyn[k], torch.zeros_like(dyn[k]), atol=1e-4), k
+
+
+def test_constant_acceleration_recovers_accel_value() -> None:
+    pred_xyz, pred_rot = _make_constant_accel(ax=2.0)
+    dyn = gather_dynamics(pred_xyz, pred_rot)
+
+    # accel_lon = diff(v_lon) = diff(diff(x)). Each _diff_pad_last call repeats
+    # the last delta, so the LAST two timesteps are unreliable after two
+    # nested differentiations. Check the genuine interior only.
+    interior_accel = dyn["accel_lon"][..., 1:-2]
+    assert torch.allclose(
+        interior_accel, torch.full_like(interior_accel, 2.0), atol=1e-2
+    ), interior_accel
+
+
+def test_yaw_rate_handles_pi_wraparound() -> None:
+    """Heading jumping from +pi to -pi must yield ~0 yaw_rate, not ~2*pi."""
+    pred_xyz = torch.zeros(1, 1, 1, 4, 3, dtype=torch.float64)
+    # Build rotations from yaw angles that wrap.
+    yaws = torch.tensor(
+        [math.pi - 0.05, math.pi - 0.01, -math.pi + 0.02, -math.pi + 0.04],
+        dtype=torch.float64,
+    )
+    cos = torch.cos(yaws)
+    sin = torch.sin(yaws)
+    pred_rot = _identity_rot(1, 1, 1, 4)
+    pred_rot[..., 0, 0] = cos
+    pred_rot[..., 1, 0] = sin
+    pred_rot[..., 0, 1] = -sin
+    pred_rot[..., 1, 1] = cos
+
+    dyn = gather_dynamics(pred_xyz, pred_rot)
+
+    # Yaw is moving forward in small increments; yaw_rate magnitude must be
+    # small (radians/s), not ~ 2*pi*10 from a naive subtraction.
+    assert torch.all(dyn["yaw_rate"].abs() < 1.0), dyn["yaw_rate"]
+
+
+def test_compute_smoothness_metrics_emits_all_keys() -> None:
+    pred_xyz, pred_rot = _make_constant_velocity()
+    out = compute_smoothness_metrics(pred_xyz, pred_rot)
+    for prefix in _SMOOTHNESS_SOURCES:
+        for suffix in ("_rms", "_max"):
+            key = prefix + suffix
+            assert key in out, f"missing key {key!r}"
+            assert out[key].shape == (pred_xyz.shape[0],), f"{key}: {out[key].shape}"
+
+
+def test_compute_smoothness_metrics_constant_velocity_is_smooth() -> None:
+    """Straight-line motion at constant speed reports near-zero everywhere."""
+    pred_xyz, pred_rot = _make_constant_velocity()
+    out = compute_smoothness_metrics(pred_xyz, pred_rot)
+    for prefix in _SMOOTHNESS_SOURCES:
+        for suffix in ("_rms", "_max"):
+            v = out[prefix + suffix]
+            assert torch.all(v.abs() < 1e-3), f"{prefix}{suffix} = {v}"
+
+
+def test_compute_smoothness_adds_std_when_N_gt_1() -> None:
+    pred_xyz, pred_rot = _make_constant_velocity(N=3)
+    out = compute_smoothness_metrics(pred_xyz, pred_rot)
+    # _std variants get added by summarize_metric.
+    for prefix in _SMOOTHNESS_SOURCES:
+        for suffix in ("_rms", "_max"):
+            assert (prefix + suffix + "_std") in out
+
+
+def test_compute_smoothness_drops_std_when_disable_summary() -> None:
+    pred_xyz, pred_rot = _make_constant_velocity(N=3)
+    out = compute_smoothness_metrics(pred_xyz, pred_rot, disable_summary=True)
+    for k in list(out.keys()):
+        assert not k.endswith("_std"), f"{k} should not be present"
+
+
+def test_compute_smoothness_rejects_wrong_shapes() -> None:
+    bad_xyz = torch.zeros(2, 3, 4, 10, dtype=torch.float64)  # missing trailing 3
+    rot = _identity_rot(2, 3, 4, 10)
+    try:
+        compute_smoothness_metrics(bad_xyz, rot)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError on missing xyz channel dim")
+
+    pred_xyz, _ = _make_constant_velocity()
+    bad_rot = torch.zeros(2, 3, 4, 10, 3, 4, dtype=torch.float64)  # 3x4 instead of 3x3
+    try:
+        compute_smoothness_metrics(pred_xyz, bad_rot)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError on non-3x3 rotation")


### PR DESCRIPTION
### Why
ADE / FDE answer **"is the trajectory accurate?"** Smoothness metrics answer **"is the trajectory drivable?"** — and right now there is no easy way to ask the second question during evaluation.

The kinematic derivations already exist in `finetune/rl/rewards/comfort_reward.py`, but they're wrapped in a within-bound boolean used as an RL reward. A researcher who wants to compare two checkpoints on "did this model produce smoother trajectories?" has no metric for that. Several open issues mention model-output quality (e.g. #10 reports occasional erratic predictions) — smoothness numbers help triage that exact class of failure.

### What
New module `src/alpamayo_r1/metrics/smoothness_metrics.py` exposing:

```python
compute_smoothness_metrics(
    pred_xyz: Tensor,          # [B, N, K, T, 3]
    pred_rot: Tensor,          # [B, N, K, T, 3, 3]
    disable_summary: bool = False,
    planning_freq_hz: float = 10.0,
) -> dict[str, Tensor]
```

Returns per-batch tensors of shape `[B]` with both the **RMS** (typical signal level) and the **absolute peak** (worst-case) of:

- `smoothness/jerk_lon`  (longitudinal jerk, m/s³)
- `smoothness/accel_lon` (longitudinal acceleration, m/s²)
- `smoothness/accel_lat` (lateral acceleration, m/s²)
- `smoothness/yaw_rate`  (rad/s)
- `smoothness/yaw_accel` (rad/s²)

Each → `<key>_rms` and `<key>_max`. `_std` variants are added by `summarize_metric` when `N > 1`, exactly mirroring `compute_minade` / `compute_minfde` so dashboards already grouping on `*_std` pick them up automatically.

Also exposes `gather_dynamics(pred_xyz, pred_rot, planning_freq_hz)` for callers that want the raw per-timestep signals.

### Design notes
- **Pure additive change.** `comfort_reward.py` is untouched. The small `_diff` / `_diff_yaw` helpers are deliberately duplicated so the `metrics` layer doesn't take a dependency on the `finetune.rl` package. The module docstring calls out the intentional duplication and the reason.
- **Yaw wraparound is handled** so a heading transition across ±π does not report the spurious ~2π·freq_hz spike a naive diff would yield.
- **Both peak and RMS** are reported because they answer different questions: peak captures worst-case discomfort, RMS captures sustained effort.
- **Shape validation up front** (`pred_xyz` must be `[B, N, K, T, 3]`, `pred_rot` must be `[B, N, K, T, 3, 3]` with matching leading dims), raising `ValueError` rather than failing deep in a tensor op.

### Tests
`src/alpamayo_r1/metrics/test_smoothness_metrics.py` — 9 pytest cases, no GPU / no HF needed. Verified locally:

```
PASS: constant velocity gives v_lon=5, zero everywhere else
PASS: constant accel ax=2 (interior mean = 2.000000)
PASS: yaw wraparound (max |yaw_rate| = 0.400000, NOT ~62)
PASS: emits 10 expected keys, shape [B]
PASS: _std variants when N>1
PASS: disable_summary drops _std
PASS: constant-velocity reports near-zero on all signals
PASS: rejects xyz wrong shape
PASS: rejects rot wrong shape
```

Test fixtures use `float64` to keep finite-difference noise at machine precision (twice-differentiating a 0.1 s step in `float32` accumulates ~1e-4 jerk noise that would force loose tolerances and make the contract less crisp).

### Migration
None. New module, new file, new tests. Existing call sites untouched.