### PR TITLE
Point Alpamayo recipes to shared repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 ## Updates
 
-- [April 2026] ⚙️ Fine-tuning scripts released in [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes): [SFT](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_sft) for supervised fine-tuning and [RL](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl) for reinforcement learning-based post-training.
+- [May 2026] Fine-tuning and post-training scripts moved to [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes): [SFT](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_sft) and [RL](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl).
+- [April 2026] ⚙️ [Fine-tuning scripts](#fine-tuning-scripts) released: [SFT](docs/FINETUNE_SFT.md) for supervised fine-tuning and [RL](finetune/rl/README.md) for reinforcement learning-based post-training.
 - [March 2026] [🏔️ Alpamayo 1.5](https://github.com/NVlabs/alpamayo1.5) has been released! We recommend all users check out the new version for improved performance, new features, and continued support! 🚀
 - [January 2026] Following the release of [NVIDIA Alpamayo](https://nvidianews.nvidia.com/news/alpamayo-autonomous-vehicle-development) at CES 2026, Alpamayo-R1 has been renamed to Alpamayo 1.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Updates
 
-- [April 2026] ⚙️ [Fine-tuning scripts](#fine-tuning-scripts) released: [SFT](docs/FINETUNE_SFT.md) for supervised fine-tuning and [RL](finetune/rl/README.md) for reinforcement learning-based post-training.
+- [April 2026] ⚙️ Fine-tuning scripts released in [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes): [SFT](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_sft) for supervised fine-tuning and [RL](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl) for reinforcement learning-based post-training.
 - [March 2026] [🏔️ Alpamayo 1.5](https://github.com/NVlabs/alpamayo1.5) has been released! We recommend all users check out the new version for improved performance, new features, and continued support! 🚀
 - [January 2026] Following the release of [NVIDIA Alpamayo](https://nvidianews.nvidia.com/news/alpamayo-autonomous-vehicle-development) at CES 2026, Alpamayo-R1 has been renamed to Alpamayo 1.
 
@@ -102,14 +102,14 @@ Alpamayo 1 implements the architecture described in our paper [*"Alpamayo-R1: Br
 | **Route/navigation conditioning**       | Explicit navigation or route inputs                              | ❌ Not in this release |
 | **Meta-actions/General VQA**            | High-level behavior and visual question answering                | ❌ Not in this release |
 
-This release includes the core model, SFT scripts, and the RL post-training pipeline. RL-trained weights, route conditioning, and meta-actions are candidates for future releases.
+This release includes the core model and inference scripts. SFT scripts, the RL post-training pipeline, and future post-training recipes are maintained in [Alpamayo Recipes](https://github.com/NVlabs/alpamayo-recipes).
 
 ## Fine-tuning Scripts
 
 | Method  | Description                                              | Docs                              |
 | ------- | -------------------------------------------------------- | --------------------------------- |
-| **SFT** | Supervised fine-tuning                                   | [SFT guide](docs/FINETUNE_SFT.md) |
-| **RL**  | Reinforcement learning-based post-training via Cosmos-RL | [RL guide](finetune/rl/README.md) |
+| **SFT** | Supervised fine-tuning                                   | [SFT guide](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_sft) |
+| **RL**  | Reinforcement learning-based post-training via Cosmos-RL | [RL guide](https://github.com/NVlabs/alpamayo-recipes/tree/main/recipes/alpamayo1_x_rl) |
 
 Please refer to the linked guides for compute requirements, step-by-step
 instructions, and fine-tuning FAQ.


### PR DESCRIPTION
## Summary

- point Alpamayo 1 SFT users to the Alpamayo Recipes SFT guide
- point Alpamayo 1.x RL/post-training users to the Alpamayo Recipes RL guide
- update README wording so post-training recipes are maintained in the shared recipes repo

## Notes

This is documentation-only.