### PR TITLE
Avoid duplicate PAI preprocessing

### DIFF
--- a/src/alpamayo_r1/data/pai.py
+++ b/src/alpamayo_r1/data/pai.py
@@ -117,9 +117,6 @@ class PAIDataset(Dataset):
             if key.startswith("ego_"):
                 sample_data[key] = sample_data[key].squeeze(0)
 
-        if self.vla_preprocess_func is not None:
-            sample_data["tokenized_data"] = self.vla_preprocess_func(data=sample_data)
-
         if self.include_extr_intr:
             sample_data["extr"] = self.avdi.get_clip_feature(clip_id, "sensor_extrinsics")
             sample_data["intr"] = self.avdi.get_clip_feature(clip_id, "camera_intrinsics")


### PR DESCRIPTION
## Summary

Remove the earlier `vla_preprocess_func` call in `PAIDataset.__getitem__`, leaving preprocessing to run once after the optional calibration metadata and RL reshaping steps.

## Why

The first preprocessing pass is overwritten by the final pass, so it adds unnecessary work and runs before the sample has reached its final shape.

Fixes #105.

## Testing

- `python3 -m py_compile src/alpamayo_r1/data/pai.py`
- `git diff --check origin/main..HEAD`